### PR TITLE
Added `GetNodes` API

### DIFF
--- a/src/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/src/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="DefaultValueForPositionalArgumentsTests.cs" />
     <Compile Include="DocoptTests.cs" />
     <Compile Include="EitherMatchTests.cs" />
+    <Compile Include="GetNodesTests.cs" />
     <Compile Include="GenerateCodeTests.cs" />
     <Compile Include="LanguageAgnosticTests.cs" />
     <Compile Include="LanguageAgnosticTests.generated.cs">

--- a/src/DocoptNet.Tests/GetNodesTests.cs
+++ b/src/DocoptNet.Tests/GetNodesTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace DocoptNet.Tests
+{
+    [TestFixture]
+    public class GetNodesTests
+    {
+        [Test]
+        public void Should_get_nodes()
+        {
+            const string USAGE = @"Test host app for T4 Docopt.NET
+
+Usage:
+  prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch]
+  prog files FILE...
+
+Options:
+ -o --opt     Short switch with a longer name. The longer name is the ""main"" one.
+ -s=<arg>     Short option with arg.
+ --long=ARG   Long option with arg.
+ --switch     Long switch. [default: false]
+
+Explanation:
+ This is a test ""usage"".
+";
+
+            var actual = new Docopt().GetNodes(USAGE);
+            
+            CollectionAssert.AreEqual(
+                new Node[]
+                {
+                    new CommandNode ("command"),
+                    new ArgumentNode("ARG",         ValueType.String),
+                    new ArgumentNode("<myarg>",     ValueType.String),
+                    new ArgumentNode("OPTIONALARG", ValueType.String),
+                    new OptionNode  ("opt",         ValueType.Bool),
+                    new OptionNode  ("s",           ValueType.String),
+                    new OptionNode  ("long",        ValueType.String),
+                    new OptionNode  ("switch",      ValueType.Bool),
+                    new CommandNode ("files"),
+                    new ArgumentNode("FILE",        ValueType.List),
+                },
+                actual);
+        }
+
+        [Test]
+        public void Should_return_duplicates_so_caller_knows_which_args_are_after_each_command()
+        {
+            const string USAGE = @"Test for duplicate commands and arguments.
+Usage:
+  prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch]
+  prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch] FILE... 
+  prog diff-command <myarg> [OPTIONALARG] ARG
+
+Options:
+ -o --option  Short & long option flag, the long will be used as it's more descriptive.
+ -s=<arg>     Short option with arg.
+ --long=ARG   Long option with arg.
+ --switch     Long switch.
+";
+
+            var actual = new Docopt().GetNodes(USAGE);
+
+            CollectionAssert.AreEqual(
+                new Node[]
+                {
+                    new CommandNode ("command"),
+                    new ArgumentNode("ARG",         ValueType.String),
+                    new ArgumentNode("<myarg>",     ValueType.String),
+                    new ArgumentNode("OPTIONALARG", ValueType.String),
+                    new OptionNode  ("option",      ValueType.Bool),
+                    new OptionNode  ("s",           ValueType.String),
+                    new OptionNode  ("long",        ValueType.String),
+                    new OptionNode  ("switch",      ValueType.Bool),
+                    new CommandNode ("command"),
+                    new ArgumentNode("ARG",         ValueType.String),
+                    new ArgumentNode("<myarg>",     ValueType.String),
+                    new ArgumentNode("OPTIONALARG", ValueType.String),
+                    new OptionNode  ("option",      ValueType.Bool),
+                    new OptionNode  ("s",           ValueType.String),
+                    new OptionNode  ("long",        ValueType.String),
+                    new OptionNode  ("switch",      ValueType.Bool),
+                    new ArgumentNode("FILE",        ValueType.List),
+                    new CommandNode ("diff-command"),
+                    new ArgumentNode("<myarg>",     ValueType.String),
+                    new ArgumentNode("OPTIONALARG", ValueType.String),
+                    new ArgumentNode("ARG",         ValueType.String),
+                },
+                actual);
+        }
+    }
+}

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -34,6 +34,11 @@ namespace DocoptNet
             return new SingleMatchResult();
         }
 
+        public override Node ToNode()
+        {
+            return new ArgumentNode(this.Name, (this.Value != null && this.Value.IsList) ? ValueType.List : ValueType.String);
+        }
+
         public override string GenerateCode()
         {
             var s = Name.Replace("<", "").Replace(">", " ").ToLowerInvariant();

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -23,6 +23,8 @@ namespace DocoptNet
             return new SingleMatchResult();
         }
 
+        public override Node ToNode() { return new CommandNode(this.Name); }
+
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -93,6 +93,25 @@ namespace DocoptNet
 
         public string GenerateCode(string doc)
         {
+            var res = GetFlatPatterns(doc);
+            var sb = new StringBuilder();
+            foreach (var p in res)
+            {
+                sb.AppendLine(p.GenerateCode());
+            }
+            return sb.ToString();
+        }
+
+        public IEnumerable<Node> GetNodes(string doc)
+        {
+            return GetFlatPatterns(doc)
+                .Select(p => p.ToNode())
+                .Where(p => p != null)
+                .ToArray();
+        }
+
+        static IEnumerable<Pattern> GetFlatPatterns(string doc)
+        {
             var usageSections = ParseSection("usage:", doc);
             if (usageSections.Length == 0)
                 throw new DocoptLanguageErrorException("\"usage:\" (case-insensitive) not found.");
@@ -108,13 +127,7 @@ namespace DocoptNet
                 var docOptions = ParseDefaults(doc);
                 optionsShortcut.Children = docOptions.Distinct().Except(patternOptions).ToList();
             }
-            var res = pattern.Fix();
-            var sb = new StringBuilder();
-            foreach (var p in res.Flat())
-            {
-                sb.AppendLine(p.GenerateCode());
-            }
-            return sb.ToString();
+            return pattern.Fix().Flat();
         }
 
         private void Extras(bool help, object version, ICollection<Pattern> options, string doc)

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Either.cs" />
     <Compile Include="LeafPattern.cs" />
     <Compile Include="MatchResult.cs" />
+    <Compile Include="Node.cs" />
     <Compile Include="OneOrMore.cs" />
     <Compile Include="Option.cs" />
     <Compile Include="Optional.cs" />

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DocoptNet
+{
+    public enum ValueType { Bool, List, String, }
+
+    public class ArgumentNode : Node
+    {
+        public ArgumentNode(string name, ValueType valueType) : base(name, valueType) { }
+    }
+
+    public class OptionNode : Node
+    {
+        public OptionNode(string name, ValueType valueType) : base(name, valueType) { }
+    }
+
+    public class CommandNode : Node
+    {
+        public CommandNode(string name) : base(name, ValueType.Bool) { }
+    }
+
+    public abstract class Node : IEquatable<Node>
+    {
+        private class EmptyNode : Node
+        {
+            public EmptyNode() : base("", (ValueType)0) { }
+        }
+
+        /// <summary>
+        /// Indicates an empty or non-existant node.
+        /// </summary>
+        public static readonly Node Empty = new EmptyNode();
+
+        protected Node(string name, ValueType valueType)
+        {
+            if (name == null) throw new ArgumentNullException("name");
+
+            this.Name = name;
+            this.ValueType = valueType;
+        }
+
+        public ValueType ValueType { get; private set; }
+        public string Name { get; private set; }
+
+        public override string ToString()
+        {
+            return string.Format("{0} {1} {2}", GetType().Name, Name, ValueType);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Name.GetHashCode() ^ this.ValueType.GetHashCode();
+        }
+
+        public bool Equals(Node other)
+        {
+            if (object.ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other.Name == this.Name
+                && other.ValueType == this.ValueType;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (object.ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (object.ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((Node)obj);
+        }
+    }
+
+}

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -30,6 +30,11 @@ namespace DocoptNet
             get { return LongName ?? ShortName; }
         }
 
+        public override Node ToNode()
+        {
+            return new OptionNode(this.Name.TrimStart('-'), this.ArgCount == 0 ? ValueType.Bool : ValueType.String);
+        }
+
         public override string GenerateCode()
         {
             var s = Name.Replace("-", "").ToLowerInvariant();

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -20,6 +20,11 @@ namespace DocoptNet
             return "// No code for " + Name;
         }
 
+        public virtual Node ToNode()
+        {
+            return null;
+        }
+
         // override object.Equals
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
The API allows callers to inspect the commands, options, and arguments parsed from a doc string.

The ultimate goal here is to create an [F# Type Provider](https://github.com/adamchester/DocoptNetProvider), however this API should be useful anywhere people want to use [`GenerateCode`](https://github.com/docopt/docopt.net/blob/master/src/DocoptNet/Docopt.cs#L94) (and cant use the currently generated C# properties string). 

I am pretty sure `Node` is not the best possible name - but I thought it best to get feedback on that one.