### PR TITLE
Support for dashes in T4 generation (converting dashes to camel case)

### DIFF
--- a/src/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/src/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -104,7 +104,6 @@
     <Compile Include="ValueObjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/src/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="DefaultValueForPositionalArgumentsTests.cs" />
     <Compile Include="DocoptTests.cs" />
     <Compile Include="EitherMatchTests.cs" />
+    <Compile Include="GenerateCodeHelperTest.cs" />
     <Compile Include="GetNodesTests.cs" />
     <Compile Include="GenerateCodeTests.cs" />
     <Compile Include="LanguageAgnosticTests.cs" />
@@ -103,6 +104,7 @@
     <Compile Include="ValueObjectTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.5.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -1,0 +1,17 @@
+﻿using NUnit.Framework;
+
+namespace DocoptNet.Tests
+{
+    [TestFixture]
+    public class GenerateCodeHelperTest
+    {
+        [Test]
+        public void GenerateCode()
+        {
+            var input = "string-with-dashes";
+            var expected = "StringWithDashes";
+            var actual = GenerateCodeHelper.GenerateCode(input);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -6,11 +6,36 @@ namespace DocoptNet.Tests
     public class GenerateCodeHelperTest
     {
         [Test]
-        public void GenerateCode()
+        public void ConvertDashesToCamelCase_single_dashes()
         {
-            var input = "string-with-dashes";
+            var actual = GenerateCodeHelper.ConvertDashesToCamelCase("string-with-dashes");
+            Assert.AreEqual("StringWithDashes", actual);
+        }
+
+        [Test]
+        public void ConvertDashesToCamelCase_consecutive_dashes()
+        {
+            var input = "string--with----dashes";
             var expected = "StringWithDashes";
-            var actual = GenerateCodeHelper.GenerateCode(input);
+            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ConvertDashesToCamelCase_existing_uppercase_letters()
+        {
+            var input = "string-With-Dashes";
+            var expected = "StringWithDashes";
+            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ConvertDashesToCamelCase_all_uppercase_letters()
+        {
+            var input = "STRING-WITH-DASHES";
+            var expected = "STRINGWITHDASHES";
+            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
             Assert.AreEqual(expected, actual);
         }
     }

--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -15,14 +15,14 @@ namespace DocoptNet.Tests
             const string USAGE = @"Test host app for T4 Docopt.NET
 
 Usage:
-  prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch]
+  prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch-dash]
   prog files FILE...
 
 Options:
- -o           Short switch.
- -s=<arg>     Short option with arg.
- --long=ARG   Long option with arg.
- --switch     Long switch.
+ -o                Short switch.
+ -s=<arg>          Short option with arg.
+ --long=ARG        Long option with arg.
+ --switch-dash     Long switch.
 
 Explanation:
  This is a test usage file.
@@ -35,7 +35,7 @@ public string ArgOptionalarg { get { return _args[""OPTIONALARG""].ToString(); }
 public bool OptO { get { return _args[""-o""].IsTrue; } }
 public string OptS { get { return _args[""-s""].ToString(); } }
 public string OptLong { get { return _args[""--long""].ToString(); } }
-public bool OptSwitch { get { return _args[""--switch""].IsTrue; } }
+public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
 public bool CmdFiles { get { return _args[""files""].IsTrue; } }
 public ArrayList ArgFile { get { return _args[""FILE""].AsList; } }
 ";

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -42,7 +42,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.Replace("<", "").Replace(">", " ").ToLowerInvariant();
-            s = "Arg" + char.ToUpperInvariant(s[0]) + s.Substring(1);
+            s = "Arg" + GenerateCodeHelper.GenerateCode(s);
 
             if (Value != null && Value.IsList)
             {

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -42,7 +42,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.Replace("<", "").Replace(">", " ").ToLowerInvariant();
-            s = "Arg" + GenerateCodeHelper.GenerateCode(s);
+            s = "Arg" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
 
             if (Value != null && Value.IsList)
             {

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -28,7 +28,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();
-            s = "Cmd" + char.ToUpperInvariant(s[0]) + s.Substring(1);
+            s = "Cmd" + GenerateCodeHelper.GenerateCode(s);
             return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
         }
 

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -28,7 +28,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();
-            s = "Cmd" + GenerateCodeHelper.GenerateCode(s);
+            s = "Cmd" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
             return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
         }
 

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DocoptInputErrorException.cs" />
     <Compile Include="DocoptLanguageErrorException.cs" />
     <Compile Include="Either.cs" />
+    <Compile Include="GenerateCodeHelper.cs" />
     <Compile Include="LeafPattern.cs" />
     <Compile Include="MatchResult.cs" />
     <Compile Include="Node.cs" />

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -1,0 +1,25 @@
+﻿namespace DocoptNet
+{
+    public class GenerateCodeHelper
+    {
+        public static string GenerateCode(string s)
+        {
+            // Start with uppercase char
+            var makeUpperCase = true;
+            var result = "";
+            for (int i = 0; i < s.Length; i++)
+            {
+                if(s[i] == '-')
+                {
+                    makeUpperCase = true;
+                    continue;
+                }
+
+                result += makeUpperCase ? char.ToUpperInvariant(s[i]) : s[i];
+                makeUpperCase = false;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -2,7 +2,7 @@
 {
     public static class GenerateCodeHelper
     {
-        public static string GenerateCode(string s)
+        public static string ConvertDashesToCamelCase(string s)
         {
             // Start with uppercase char
             var makeUpperCase = true;

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -1,6 +1,6 @@
 ﻿namespace DocoptNet
 {
-    public class GenerateCodeHelper
+    public static class GenerateCodeHelper
     {
         public static string GenerateCode(string s)
         {

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace DocoptNet
@@ -37,8 +38,8 @@ namespace DocoptNet
 
         public override string GenerateCode()
         {
-            var s = Name.Replace("-", "").ToLowerInvariant();
-            s = "Opt" + char.ToUpperInvariant(s[0]) + s.Substring(1);
+            var s = Name.ToLowerInvariant();
+            s = "Opt" + GenerateCodeHelper.GenerateCode(s);
 
             if (ArgCount == 0)
             {

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -39,7 +39,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();
-            s = "Opt" + GenerateCodeHelper.GenerateCode(s);
+            s = "Opt" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
 
             if (ArgCount == 0)
             {


### PR DESCRIPTION
Hi,

I think that the title says it all. I added dash support and one simple unit test for it. This way I can use dashes in docopt usages like "do-something" and they will look fine in the code generated by the T4 template.

Best,
Jefim