### PR TITLE
Fix Option/Arg Null Reference Exception

### DIFF
--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -29,12 +29,12 @@ Explanation:
 ";
             const string expected = @"
 public bool CmdCommand { get { return _args[""command""].IsTrue; } }
-public string ArgArg { get { return _args[""ARG""].ToString(); } }
-public string ArgMyarg  { get { return _args[""<myarg>""].ToString(); } }
-public string ArgOptionalarg { get { return _args[""OPTIONALARG""].ToString(); } }
+public string ArgArg { get { return null == _args[""ARG""] ? null : _args[""ARG""].ToString(); } }
+public string ArgMyarg  { get { return null == _args[""<myarg>""] ? null : _args[""<myarg>""].ToString(); } }
+public string ArgOptionalarg { get { return null == _args[""OPTIONALARG""] ? null : _args[""OPTIONALARG""].ToString(); } }
 public bool OptO { get { return _args[""-o""].IsTrue; } }
-public string OptS { get { return _args[""-s""].ToString(); } }
-public string OptLong { get { return _args[""--long""].ToString(); } }
+public string OptS { get { return null == _args[""-s""] ? null : _args[""-s""].ToString(); } }
+public string OptLong { get { return null == _args[""--long""] ? null : _args[""--long""].ToString(); } }
 public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
 public bool CmdFiles { get { return _args[""files""].IsTrue; } }
 public ArrayList ArgFile { get { return _args[""FILE""].AsList; } }

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -48,7 +48,7 @@ namespace DocoptNet
             {
                 return string.Format("public ArrayList {0} {{ get {{ return _args[\"{1}\"].AsList; }} }}", s, Name);
             }
-            return string.Format("public string {0} {{ get {{ return _args[\"{1}\"].ToString(); }} }}", s, Name);
+            return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? null : _args[\"{1}\"].ToString(); }} }}", s, Name);
         }
     }
 }

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -45,7 +45,7 @@ namespace DocoptNet
             {
                 return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
             }
-            return string.Format("public string {0} {{ get {{ return _args[\"{1}\"].ToString(); }} }}", s, Name);
+            return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? null : _args[\"{1}\"].ToString(); }} }}", s, Name);
         }
 
         public override SingleMatchResult SingleMatch(IList<Pattern> left)


### PR DESCRIPTION
Fixed NullReferenceException caused by calling .ToString() on an
argument or option that was not assigned. The value returned for an
unassigned option or argument is null. This was chosen over an empty
string as a user could input an empty string.

See Issue #14