### PR TITLE
Fix Multiple Definition Bug

### DIFF
--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -16,6 +16,7 @@ namespace DocoptNet.Tests
 
 Usage:
   prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch-dash]
+  prog command2 ARG <myarg>
   prog files FILE...
 
 Options:
@@ -36,6 +37,7 @@ public bool OptO { get { return _args[""-o""].IsTrue; } }
 public string OptS { get { return null == _args[""-s""] ? null : _args[""-s""].ToString(); } }
 public string OptLong { get { return null == _args[""--long""] ? null : _args[""--long""].ToString(); } }
 public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
+public bool CmdCommand2 { get { return _args[""command2""].IsTrue; } }
 public bool CmdFiles { get { return _args[""files""].IsTrue; } }
 public ArrayList ArgFile { get { return _args[""FILE""].AsList; } }
 ";

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -94,6 +94,9 @@ namespace DocoptNet
         public string GenerateCode(string doc)
         {
             var res = GetFlatPatterns(doc);
+            res = res
+                .GroupBy(pattern => pattern.Name)
+                .Select(group => group.First());
             var sb = new StringBuilder();
             foreach (var p in res)
             {


### PR DESCRIPTION
Fixed issue of multiple definitions being created if an argument name
was reused in a different command. This was done by adding a distinct
check by name for each argument before writing the source file.

See Issue #28