### PR TITLE
Fix Unused Default Values Issue

### DIFF
--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -21,7 +21,7 @@ Usage:
 
 Options:
  -o                Short switch.
- -s=<arg>          Short option with arg.
+ -s=<arg>          Short option with arg. [default: 128]
  --long=ARG        Long option with arg.
  --switch-dash     Long switch.
 
@@ -34,7 +34,7 @@ public string ArgArg { get { return null == _args[""ARG""] ? null : _args[""ARG"
 public string ArgMyarg  { get { return null == _args[""<myarg>""] ? null : _args[""<myarg>""].ToString(); } }
 public string ArgOptionalarg { get { return null == _args[""OPTIONALARG""] ? null : _args[""OPTIONALARG""].ToString(); } }
 public bool OptO { get { return _args[""-o""].IsTrue; } }
-public string OptS { get { return null == _args[""-s""] ? null : _args[""-s""].ToString(); } }
+public string OptS { get { return null == _args[""-s""] ? ""128"" : _args[""-s""].ToString(); } }
 public string OptLong { get { return null == _args[""--long""] ? null : _args[""--long""].ToString(); } }
 public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
 public bool CmdCommand2 { get { return _args[""command2""].IsTrue; } }

--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -16,6 +16,7 @@ namespace DocoptNet.Tests
 
 Usage:
   prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch-dash]
+  prog command2 ARG <myarg>
   prog files FILE...
 
 Options:
@@ -36,6 +37,7 @@ public bool OptO { get { return _args[""-o""].IsTrue; } }
 public string OptS { get { return null == _args[""-s""] ? null : _args[""-s""].ToString(); } }
 public string OptLong { get { return null == _args[""--long""] ? null : _args[""--long""].ToString(); } }
 public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
+public bool CmdCommand2 { get { return _args[""command2""].IsTrue; } }
 public bool CmdFiles { get { return _args[""files""].IsTrue; } }
 public ArrayList ArgFile { get { return _args[""FILE""].AsList; } }
 ";

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -94,6 +94,9 @@ namespace DocoptNet
         public string GenerateCode(string doc)
         {
             var res = GetFlatPatterns(doc);
+            res = res
+                .GroupBy(pattern => pattern.Name)
+                .Select(group => group.First());
             var sb = new StringBuilder();
             foreach (var p in res)
             {

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -45,7 +45,8 @@ namespace DocoptNet
             {
                 return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
             }
-            return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? null : _args[\"{1}\"].ToString(); }} }}", s, Name);
+            var defaultValue = Value == null ? "null" : string.Format("\"{0}\"", Value);
+            return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? {2} : _args[\"{1}\"].ToString(); }} }}", s, Name, defaultValue);
         }
 
         public override SingleMatchResult SingleMatch(IList<Pattern> left)


### PR DESCRIPTION
Fixed issue where default values were being parsed but unused. This was
done by adding a check to return the default value if one was set rather
than returning null.

See Issue #30