### PR TITLE
Create local scope for build batch script variables

### DIFF
--- a/build/Build.bat
+++ b/build/Build.bat
@@ -1,4 +1,5 @@
 @ECHO OFF
+SETLOCAL
 SET MSBUILD=C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
 SET VERBOSE=normal
 SET BUILDIR=%~dp0


### PR DESCRIPTION
This PR proposes a small fix to `Build.bat` to create a local scope for the script's variables. Without the `setlocal`, the variables leak into the caller's/shell's environment.
