### PR TITLE
Fix string partitioning bug when separator is at start

### DIFF
--- a/src/DocoptNet.Tests/StringPartitionTests.cs
+++ b/src/DocoptNet.Tests/StringPartitionTests.cs
@@ -5,13 +5,14 @@ namespace DocoptNet.Tests
     [TestFixture]
     public class StringPartitionTests
     {
-        [Test]
-        public void Should_partition_string()
+        [TestCase("left=right", "left", "=", "right")]
+        [TestCase("=right", "", "=", "right")]
+        public void Should_partition_string(string input, string left, string separator, string right)
         {
-            var p = new StringPartition("left=right", "=");
-            Assert.AreEqual("left", p.LeftString);
-            Assert.AreEqual("=", p.Separator);
-            Assert.AreEqual("right", p.RightString);
+            var p = new StringPartition(input, separator);
+            Assert.AreEqual(left, p.LeftString);
+            Assert.AreEqual(separator, p.Separator);
+            Assert.AreEqual(right, p.RightString);
         }
 
         [Test]

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -74,7 +74,7 @@ namespace DocoptNet
             string longName = null;
             var argCount = 0;
             var value = new ValueObject(false);
-            var p = new StringPartition(optionDescription, DESC_SEPARATOR);
+            var p = new StringPartition(optionDescription.Trim(), DESC_SEPARATOR);
             var options = p.LeftString;
             var description = p.RightString;
             foreach (var s in options.Split(" \t,=".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))

--- a/src/DocoptNet/StringPartition.cs
+++ b/src/DocoptNet/StringPartition.cs
@@ -20,7 +20,7 @@
             RightString = "";
 
             var i = stringToPartition.IndexOf(separator, System.StringComparison.Ordinal);
-            if (i > 0)
+            if (i >= 0)
             {
                 LeftString = stringToPartition.Substring(0, i);
                 Separator = separator;


### PR DESCRIPTION
This PR fixes a bug in `StringPartition` when the separator is at the start of the input string. The behaviour is now compatible with [`str.partition` in Python](https://docs.python.org/3/library/stdtypes.html#str.partition):

    PS> docker run --rm --entrypoint=python python:3-alpine -c 'print((''left=right'').partition(''=''))'
    ('left', '=', 'right')

A test case has been added to cover this.

The fix cause the `OptionParseTests.Leading_spaces` test to fail so I trimmed the description before partitioning, [which is what the reference implementation does too](https://github.com/docopt/docopt/blob/20b9c4ffec71d17cee9fd963238c8ec240905b65/docopt.py#L190).
