### PR TITLE
Update VS version stamp in solution file to 2019

### DIFF
--- a/src/DocoptNet.sln
+++ b/src/DocoptNet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{78331D52-9B59-4779-933C-EFE1C19D0D2B}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
A small PR to fix/update the VS version stamp in the solution file to 2019. This aligns with the CI image change in PR #47.
