### PR TITLE
Test newer (LTS) runtimes & drop unsupported ones

### DIFF
--- a/src/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/src/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5;netcoreapp3.1;netcoreapp2.1;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
This PR updates the test project to target newer (LTS) runtimes & drop those that have reached end of life.

Drops runtimes that have reached end of life:

- [.NET Core 1.1](https://dotnet.microsoft.com/download/dotnet/1.1)

Targets newer runtimes:

- [.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet/3.1) (LTS)
- [.NET 5](https://dotnet.microsoft.com/download/dotnet/5.0)
