### PR TITLE
Change example + testee to target .NET 5 runtime

### DIFF
--- a/src/Examples/NavalFate/App.config
+++ b/src/Examples/NavalFate/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/src/Examples/NavalFate/NavalFate.csproj
+++ b/src/Examples/NavalFate/NavalFate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LanguageAgnosticTests/README.md
+++ b/src/LanguageAgnosticTests/README.md
@@ -6,7 +6,7 @@ Method 1: testee app
 1. Compile the Testee project
 2. Run the following commands
 	cd src\LanguageAgnosticTests
-    python language_agnostic_tester.py ..\Testee\bin\Debug\net45\Testee.exe
+    python language_agnostic_tester.py ..\Testee\bin\Debug\net5.0\Testee.exe
 
 Method 2: generated unit tests
 ------------------------------

--- a/src/Testee/App.config
+++ b/src/Testee/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/src/Testee/Program.cs
+++ b/src/Testee/Program.cs
@@ -3,8 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using DocoptNet;
-using Newtonsoft.Json;
 
 namespace Testee
 {
@@ -35,7 +36,23 @@ namespace Testee
                     else
                         dict[argument.Key] = argument.Value.Value;
                 }
-                return JsonConvert.SerializeObject(dict);
+                return JsonSerializer.Serialize(dict, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    //
+                    // Compared to the default encoder, the UnsafeRelaxedJsonEscaping encoder is
+                    // more permissive about allowing characters to pass through unescaped:
+                    //
+                    // - It doesn't escape HTML-sensitive characters such as "<", ">", "&", and "'".
+                    // - It doesn't offer any additional defense-in-depth protections against XSS or
+                    //   information disclosure attacks, such as those which might result from the
+                    //   client and server disagreeing on the charset.
+                    //
+                    // Since this is not expected to be used in the web context, the more relaxed
+                    // escaping is acceptable and less surprising.
+                    //
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                });
             }
             catch (Exception)
             {

--- a/src/Testee/Testee.csproj
+++ b/src/Testee/Testee.csproj
@@ -2,15 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\DocoptNet\DocoptNet.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="5.0.5" />
+    <ProjectReference Include="..\..\src\DocoptNet\DocoptNet.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR changes the target runtime of the two executable projects, **Testee** and **NavalFate** example, from .NET Framework 4.5 to .NET 5. 

**Testee** now uses built-in JSON serialization and removes the need to depend on [Json.NET](https://www.newtonsoft.com/json).
