### PR TITLE
Consistently use "net5.0" TFM

### DIFF
--- a/src/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/src/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5;netcoreapp3.1;netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
The .NET 5 TFM specification in the test project read `net5`. This PR changes it to add the minor version suffix so that all projects targeting .NET 5 in the solution consistently use `net5.0`.