### PR TITLE
Drop .NET Framework 4.0 target

### DIFF
--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyName>DocoptNet</AssemblyName>
     <Version>0.6.1.11</Version>
     <AssemblyOriginatorKeyFile>DocoptNet.snk</AssemblyOriginatorKeyFile>

--- a/src/T4DocoptNetHostApp/T4DocoptNetHostApp.csproj
+++ b/src/T4DocoptNetHostApp/T4DocoptNetHostApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Per [Lifecycle FAQ - .NET Framework][1]:

> .NET Framework 4 did not ship in any operating system. Support for the .NET Framework 4 on Windows Server 2003 SP2 ended on July 14, 2015, and support on all other operating systems ended on January 12, 2016.

The [.NET Standard 1.5](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support) target has later and supported versions of .NET Framework covered.

[1]: https://docs.microsoft.com/en-US/lifecycle/faq/dotnet-framework
