### PR TITLE
Enable & fix null analysis warnings (as errors)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>9</LangVersion>
+    <Nullable>warnings</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/DocoptNet.sln
+++ b/DocoptNet.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		appveyor.yml = appveyor.yml
+		Directory.Build.props = Directory.Build.props
 		global.json = global.json
 		LICENSE-MIT = LICENSE-MIT
 		README.rst = README.rst

--- a/src/DocoptNet.Tests/LanguageAgnosticTests.cs
+++ b/src/DocoptNet.Tests/LanguageAgnosticTests.cs
@@ -22,12 +22,9 @@ namespace DocoptNet.Tests
                     else if (argument.Value.IsList)
                     {
                         var l = new ArrayList();
-                        foreach (var v in argument.Value.AsList)
+                        foreach (var item in argument.Value.AsList)
                         {
-                            if (v is ValueObject)
-                                l.Add(((v) as ValueObject).Value);
-                            else
-                                l.Add(v);
+                            l.Add(item is ValueObject { Value: var v } ? v : item);
                         }
                         dict[argument.Key] = l;
                     }

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -2,6 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
+    <!--
+    TODO Remove the suppression of the following warnings after addressing them:
+    - error NU5125: The 'licenseUrl' element will be deprecated.
+      Consider using the 'license' element instead.
+    - error NU5048: The 'PackageIconUrl'/'iconUrl' element is deprecated.
+      Consider using the 'PackageIcon'/'icon' element instead.
+      Learn more at https://aka.ms/deprecateIconUrl
+    -->
+    <NoWarn>$(NoWarn);NU5125;NU5048</NoWarn>
     <AssemblyName>DocoptNet</AssemblyName>
     <Version>0.6.1.11</Version>
     <AssemblyOriginatorKeyFile>DocoptNet.snk</AssemblyOriginatorKeyFile>

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -96,7 +96,7 @@ namespace DocoptNet
 
                 foreach (var e in l)
                 {
-                    if (e is Argument || (e is Option && (e as Option).ArgCount > 0))
+                    if (e is Argument || e is Option { ArgCount: > 0 })
                     {
                         if (e.Value == null)
                         {
@@ -109,7 +109,7 @@ namespace DocoptNet
                                                  .Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
                         }
                     }
-                    if (e is Command || (e is Option && (e as Option).ArgCount == 0))
+                    if (e is Command || e is Option { ArgCount: 0 })
                     {
                         e.Value = new ValueObject(0);
                     }
@@ -141,20 +141,20 @@ namespace DocoptNet
                 {
                     var child = children.First(c => parents.Contains(c.GetType()));
                     children.Remove(child);
-                    if (child is Either)
+                    if (child is Either either)
                     {
-                        foreach (var c in (child as Either).Children)
+                        foreach (var c in either.Children)
                         {
                             var l = new List<Pattern> {c};
                             l.AddRange(children);
                             groups.Add(l);
                         }
                     }
-                    else if (child is OneOrMore)
+                    else if (child is OneOrMore oneOrMore)
                     {
                         var l = new List<Pattern>();
-                        l.AddRange((child as OneOrMore).Children);
-                        l.AddRange((child as OneOrMore).Children); // add twice
+                        l.AddRange(oneOrMore.Children);
+                        l.AddRange(oneOrMore.Children); // add twice
                         l.AddRange(children);
                         groups.Add(l);
                     }

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace DocoptNet
 {
-    public class ValueObject
+    public class ValueObject // TODO : IEquatable<ValueObject>
     {
         public object Value { get; private set; }
 
@@ -74,28 +74,17 @@ namespace DocoptNet
 
         public override bool Equals(object obj)
         {
-            //
-            // See the full list of guidelines at
-            //   http://go.microsoft.com/fwlink/?LinkID=85237
-            // and also the guidance for operator== at
-            //   http://go.microsoft.com/fwlink/?LinkId=85238
-            //
-
-            if (obj == null || GetType() != obj.GetType())
-            {
-                return false;
-            }
-
-            var v = (obj as ValueObject).Value;
-            if (Value == null && v == null) return true;
-            if (Value == null || v == null) return false;
-            if (IsList || (obj as ValueObject).IsList)
-                return Value.ToString().Equals(v.ToString());
-            return Value.Equals(v);
+            return obj is ValueObject { Value: var v } other
+                && (Value == null && v == null
+                    || Value != null && v != null
+                    // TODO avoid string allocations during equality check
+                    && (IsList || other.IsList ? Value.ToString().Equals(v.ToString())
+                                               : Value.Equals(v)));
         }
 
         public override int GetHashCode()
         {
+            // TODO avoid string allocations when getting hash code
             return ToString().GetHashCode();
         }
 
@@ -120,7 +109,7 @@ namespace DocoptNet
             if (increment.IsOfTypeInt)
             {
                 if (IsList)
-                    (Value as ArrayList).Add(increment.AsInt);
+                    ((ArrayList)Value).Add(increment.AsInt);
                 else
                     Value = increment.AsInt + AsInt;
             }

--- a/src/Testee/Program.cs
+++ b/src/Testee/Program.cs
@@ -24,12 +24,9 @@ namespace Testee
                     else if (argument.Value.IsList)
                     {
                         var l = new ArrayList();
-                        foreach (var v in argument.Value.AsList)
+                        foreach (var item in argument.Value.AsList)
                         {
-                            if (v is ValueObject)
-                                l.Add(((v) as ValueObject).Value);
-                            else
-                                l.Add(v);
+                            l.Add(item is ValueObject { Value: var v } ? v : item);
                         }
                         dict[argument.Key] = l;
                     }


### PR DESCRIPTION
This PR enables & fixes null analysis warnings.

For all projects, it:

- Enables null analysis warnings
- Treats warnings as errors
- Allows use of C# 9

It also adds to-do comments (largely around unwanted allocations that I noticed) that should be addressed eventually.
