### PR TITLE
Update "T4DocoptNetHostApp" to target .NET 5

### DIFF
--- a/src/T4DocoptNetHostApp/T4DocoptNetHostApp.csproj
+++ b/src/T4DocoptNetHostApp/T4DocoptNetHostApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates **T4DocoptNetHostApp** to target .NET 5. This decision shouldn't affect any users as the application is designed to demonstrate use of the T4 template and never distributed.