### PR TITLE
Make exceptions serializable where applicable

### DIFF
--- a/src/DocoptNet/DocoptBaseException.cs
+++ b/src/DocoptNet/DocoptBaseException.cs
@@ -1,14 +1,8 @@
-using System;
-#if NET40
-using System.Runtime.Serialization;
-#endif
-
 namespace DocoptNet
 {
-#if NET40
-    [Serializable]
-#endif
-    public class DocoptBaseException : Exception
+    using System;
+
+    public partial class DocoptBaseException : Exception
     {
         //
         // For guidelines regarding the creation of new exception types, see
@@ -31,18 +25,28 @@ namespace DocoptNet
         {
         }
 
-#if NET40
-        protected DocoptBaseException(
-            SerializationInfo info,
-            StreamingContext context)
-            : base(info, context)
-        {
-        }
-#endif
-
         public int ErrorCode
         {
             get { return 1; }
         }
     }
 }
+
+#if RUNTIME_SERIALIZATION
+
+namespace DocoptNet
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    partial class DocoptBaseException
+    {
+        protected DocoptBaseException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}
+
+#endif

--- a/src/DocoptNet/DocoptExitException.cs
+++ b/src/DocoptNet/DocoptExitException.cs
@@ -1,14 +1,8 @@
-using System;
-#if NET40
-using System.Runtime.Serialization;
-#endif
-
 namespace DocoptNet
 {
-#if NET40
-    [Serializable]
-#endif
-    public class DocoptExitException : DocoptBaseException
+    using System;
+
+    public partial class DocoptExitException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see
@@ -26,12 +20,24 @@ namespace DocoptNet
         public DocoptExitException(string message, Exception inner) : base(message, inner)
         {
         }
-#if NET40
-        protected DocoptExitException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
-        }
-#endif
     }
 }
+
+#if RUNTIME_SERIALIZATION
+
+namespace DocoptNet
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    partial class DocoptExitException
+    {
+        protected DocoptExitException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}
+
+#endif

--- a/src/DocoptNet/DocoptInputErrorException.cs
+++ b/src/DocoptNet/DocoptInputErrorException.cs
@@ -1,14 +1,8 @@
-using System;
-#if NET40
-using System.Runtime.Serialization;
-#endif
-
 namespace DocoptNet
 {
-#if NET40
-    [Serializable]
-#endif
-    public class DocoptInputErrorException : DocoptBaseException
+    using System;
+
+    public partial class DocoptInputErrorException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see
@@ -28,13 +22,24 @@ namespace DocoptNet
             : base(message, inner)
         {
         }
-#if NET40
-        protected DocoptInputErrorException(
-            SerializationInfo info,
-            StreamingContext context)
+    }
+}
+
+#if RUNTIME_SERIALIZATION
+
+namespace DocoptNet
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    partial class DocoptInputErrorException
+    {
+        protected DocoptInputErrorException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }
+
+#endif

--- a/src/DocoptNet/DocoptLanguageErrorException.cs
+++ b/src/DocoptNet/DocoptLanguageErrorException.cs
@@ -1,14 +1,8 @@
-using System;
-#if NET40
-using System.Runtime.Serialization;
-#endif
-
 namespace DocoptNet
 {
-#if NET40
-    [Serializable]
-#endif
-    public class DocoptLanguageErrorException : DocoptBaseException
+    using System;
+
+    public partial class DocoptLanguageErrorException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see
@@ -26,12 +20,24 @@ namespace DocoptNet
         public DocoptLanguageErrorException(string message, Exception inner) : base(message, inner)
         {
         }
-#if NET40
-        protected DocoptLanguageErrorException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
-        }
-#endif
     }
 }
+
+#if RUNTIME_SERIALIZATION
+
+namespace DocoptNet
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    partial class DocoptLanguageErrorException
+    {
+        protected DocoptLanguageErrorException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}
+
+#endif

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -31,6 +31,10 @@
     <PackageTags>parser;command line argument;option library;syntax;shell;beautiful;posix;python;console;command-line;docopt</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);RUNTIME_SERIALIZATION</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="..\NuGet\Main.usage.txt">
       <PackagePath>content\Main.usage.txt</PackagePath>


### PR DESCRIPTION
In PR #59, we dropped .NET Framework 4.0 as a target but serializability of exceptions was predicated on the `NET40` conditional compilation symbol. This PR brings back serializable of exceptions on .NET Standard 2.0 where serialization types from `System.Runtime.Serialization` are available. It does by introducing a more logical conditional compilation symbol named `RUNTIME_SERIALIZATION`, which is defined only for the `netstandard2.0` TFM.