### PR TITLE
Use "nameof" to capture offending argument name

### DIFF
--- a/src/DocoptNet/BranchPattern.cs
+++ b/src/DocoptNet/BranchPattern.cs
@@ -12,7 +12,7 @@ namespace DocoptNet
 
         public BranchPattern(params Pattern[] children)
         {
-            if (children == null) throw new ArgumentNullException("children");
+            if (children == null) throw new ArgumentNullException(nameof(children));
             Children = children;
         }
 
@@ -25,7 +25,7 @@ namespace DocoptNet
 
         public override ICollection<Pattern> Flat(params Type[] types)
         {
-            if (types == null) throw new ArgumentNullException("types");
+            if (types == null) throw new ArgumentNullException(nameof(types));
             if (types.Contains(this.GetType()))
             {
                 return new Pattern[] { this };

--- a/src/DocoptNet/LeafPattern.cs
+++ b/src/DocoptNet/LeafPattern.cs
@@ -28,7 +28,7 @@ namespace DocoptNet
 
         public override ICollection<Pattern> Flat(params Type[] types)
         {
-            if (types == null) throw new ArgumentNullException("types");
+            if (types == null) throw new ArgumentNullException(nameof(types));
             if (types.Length == 0 || types.Contains(this.GetType()))
             {
                 return new Pattern[] { this };

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -33,7 +33,7 @@ namespace DocoptNet
 
         protected Node(string name, ValueType valueType)
         {
-            if (name == null) throw new ArgumentNullException("name");
+            if (name == null) throw new ArgumentNullException(nameof(name));
 
             this.Name = name;
             this.ValueType = valueType;

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -67,7 +67,7 @@ namespace DocoptNet
 
         public static Option Parse(string optionDescription)
         {
-            if (optionDescription == null) throw new ArgumentNullException("optionDescription");
+            if (optionDescription == null) throw new ArgumentNullException(nameof(optionDescription));
 
             string shortName = null;
             string longName = null;

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -100,7 +100,7 @@ namespace DocoptNet
 
         internal void Add(ValueObject increment)
         {
-            if (increment == null) throw new ArgumentNullException("increment");
+            if (increment == null) throw new ArgumentNullException(nameof(increment));
 
             if (increment.Value == null) throw new InvalidOperationException("increment.Value is null");
 


### PR DESCRIPTION
A small PR to propose using `nameof` to capture formal name of an offending argument, which is lower maintenance than using string literals.