### PR TITLE
Use "var" consistently everywhere possible

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -208,7 +208,7 @@ namespace DocoptNet
             var pu = section.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
             var join = new StringBuilder();
             join.Append("( ");
-            for (int i = 1; i < pu.Length; i++)
+            for (var i = 1; i < pu.Length; i++)
             {
                 var s = pu[i];
                 if (i > 1) join.Append(" ");
@@ -453,7 +453,7 @@ namespace DocoptNet
                 var optionsText = p.RightString;
                 var a = Regex.Split("\n" + optionsText, @"\r?\n[ \t]*(-\S+?)");
                 var split = new List<string>();
-                for (int i = 1; i < a.Length - 1; i += 2)
+                for (var i = 1; i < a.Length - 1; i += 2)
                 {
                     var s1 = a[i];
                     var s2 = a[i + 1];

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -7,7 +7,7 @@ namespace DocoptNet
             // Start with uppercase char
             var makeUpperCase = true;
             var result = "";
-            for (int i = 0; i < s.Length; i++)
+            for (var i = 0; i < s.Length; i++)
             {
                 if(s[i] == '-')
                 {

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -70,7 +70,7 @@ namespace DocoptNet
         public void FixIdentities(ICollection<Pattern> uniq = null)
         {
             var listUniq = uniq ?? Flat().Distinct().ToList();
-            for (int i = 0; i < Children.Count; i++)
+            for (var i = 0; i < Children.Count; i++)
             {
                 var child = Children[i];
                 if (!child.HasChildren)

--- a/src/Testee/Program.cs
+++ b/src/Testee/Program.cs
@@ -62,7 +62,7 @@ namespace Testee
             Stream inputStream = Console.OpenStandardInput();
             var bytes = new byte[100];
             var sb = new StringBuilder();
-            int outputLength = inputStream.Read(bytes, 0, 100);
+            var outputLength = inputStream.Read(bytes, 0, 100);
             while (outputLength > 0)
             {
                 char[] chars = Encoding.UTF8.GetChars(bytes, 0, outputLength);


### PR DESCRIPTION
This PR uses `var` consistently everywhere possible. It leads to lower maintenance/edits and increases conformance with styling rules following rules in `.editorconfig`:

- `csharp_style_var_for_built_in_types`
- `csharp_style_var_when_type_is_apparent`
- `csharp_style_var_elsewhere`
