### PR TITLE
Safely escape parameterized regular expression

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -467,8 +467,8 @@ namespace DocoptNet
 
         internal static string[] ParseSection(string name, string source)
         {
-            var pattern = new Regex(@"^([^\r\n]*" + name + @"[^\r\n]*\r?\n?(?:[ \t].*?(?:\r?\n|$))*)",
-                RegexOptions.IgnoreCase | RegexOptions.Multiline);
+            var pattern = new Regex(@"^([^\r\n]*" + Regex.Escape(name) + @"[^\r\n]*\r?\n?(?:[ \t].*?(?:\r?\n|$))*)",
+                                    RegexOptions.IgnoreCase | RegexOptions.Multiline);
             return (from Match match in pattern.Matches(source) select match.Value.Trim()).ToArray();
         }
     }


### PR DESCRIPTION
This PR escapes the parameterized parts of the regular expression in `ParseSection`. While it doesn't present a problem today with the use cases, it makes the function future-proof.

---
PS This is one of those things I saw in passing and just thought best to send in a small PR.
