### PR TITLE
Use language keywords for types consistently (IDE0049)

### DIFF
--- a/src/DocoptNet/BranchPattern.cs
+++ b/src/DocoptNet/BranchPattern.cs
@@ -35,7 +35,7 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("{0}({1})", GetType().Name, String.Join(", ", Children.Select(c => c == null ? "None" : c.ToString())));
+            return string.Format("{0}({1})", GetType().Name, string.Join(", ", Children.Select(c => c == null ? "None" : c.ToString())));
         }
     }
 }

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -223,7 +223,7 @@ namespace DocoptNet
             var tokens = Tokens.FromPattern(source);
             var result = ParseExpr(tokens, options);
             if (tokens.Current() != null)
-                throw tokens.CreateException("unexpected ending: " + String.Join(" ", tokens.ToArray()));
+                throw tokens.CreateException("unexpected ending: " + string.Join(" ", tokens.ToArray()));
             return new Required(result.ToArray());
         }
 
@@ -320,7 +320,7 @@ namespace DocoptNet
                     {
                         return ParseShorts(tokens, options);
                     }
-                    if ((token.StartsWith("<") && token.EndsWith(">")) || token.All(c => Char.IsUpper(c)))
+                    if ((token.StartsWith("<") && token.EndsWith(">")) || token.All(c => char.IsUpper(c)))
                     {
                         result.Add(new Argument(tokens.Move()));
                     }
@@ -402,7 +402,7 @@ namespace DocoptNet
             {
                 // If not exact match
                 similar =
-                    options.Where(o => !String.IsNullOrEmpty(o.LongName) && o.LongName.StartsWith(longName)).ToList();
+                    options.Where(o => !string.IsNullOrEmpty(o.LongName) && o.LongName.StartsWith(longName)).ToList();
             }
             if (similar.Count > 1)
             {

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -58,7 +58,7 @@ namespace DocoptNet
             get
             {
                 int value;
-                return Value != null && (Value is int || Int32.TryParse(Value.ToString(), out value));
+                return Value != null && (Value is int || int.TryParse(Value.ToString(), out value));
             }
         }
 
@@ -93,7 +93,7 @@ namespace DocoptNet
             if (IsList)
             {
                 var l = (from object v in AsList select v.ToString()).ToList();
-                return string.Format("[{0}]", String.Join(", ", l));
+                return string.Format("[{0}]", string.Join(", ", l));
             }
             return (Value ?? "").ToString();
         }


### PR DESCRIPTION
There were mixed uses of reference types and equivalent language keywords (e.g. `string` and `String`). This PR makes the code base consistent with following styles in editor config:

https://github.com/docopt/docopt.net/blob/9a7f593ebc972596943704fdea33817b0e091ad5/.editorconfig#L74-L77