### PR TITLE
Move "Value" to "LeafPattern"; reveals more honest signatures

### DIFF
--- a/src/DocoptNet.Tests/ArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ArgumentMatchTests.cs
@@ -9,8 +9,8 @@ namespace DocoptNet.Tests
         public void Should_match_arg()
         {
             Assert.AreEqual(
-                new MatchResult(true, new Pattern[0], new Pattern[] {new Argument("N", new ValueObject(9))}),
-                new Argument("N").Match(new Pattern[] {new Argument(null, new ValueObject(9))})
+                new MatchResult(true, new LeafPattern[0], new LeafPattern[] {new Argument("N", new ValueObject(9))}),
+                new Argument("N").Match(new LeafPattern[] {new Argument(null, new ValueObject(9))})
                 );
         }
 
@@ -18,8 +18,8 @@ namespace DocoptNet.Tests
         public void Should_not_match_arg()
         {
             Assert.AreEqual(
-                new MatchResult(false, new Pattern[] {new Option("-x")}, new Pattern[0]),
-                new Argument("N").Match(new Pattern[] {new Option("-x")})
+                new MatchResult(false, new LeafPattern[] {new Option("-x")}, new LeafPattern[0]),
+                new Argument("N").Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -27,14 +27,14 @@ namespace DocoptNet.Tests
         public void Should_match_arg_after_opts()
         {
             Assert.AreEqual(
-                new MatchResult(true, new Pattern[] {new Option("-x"), new Option("-a")},
-                                new Pattern[] {new Argument("N", new ValueObject(5))}),
-                new Argument("N").Match(new Pattern[]
-                    {
-                        new Option("-x"),
-                        new Option("-a"),
-                        new Argument(null, new ValueObject(5))
-                    })
+                new MatchResult(true, new LeafPattern[] {new Option("-x"), new Option("-a")},
+                                new LeafPattern[] {new Argument("N", new ValueObject(5))}),
+                new Argument("N").Match(new LeafPattern[]
+                {
+                    new Option("-x"),
+                    new Option("-a"),
+                    new Argument(null, new ValueObject(5))
+                })
                 );
         }
 
@@ -43,10 +43,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                    new Pattern[] {new Argument(null, new ValueObject(0))},
-                    new Pattern[] {new Argument("N", new ValueObject(9))}),
-                new Argument("N").Match(new Pattern[]
-                    {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(0))})
+                    new LeafPattern[] {new Argument(null, new ValueObject(0))},
+                    new LeafPattern[] {new Argument("N", new ValueObject(9))}),
+                new Argument("N").Match(new LeafPattern[]
+                                            {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(0))})
                 );
         }
     }

--- a/src/DocoptNet.Tests/ArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ArgumentMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -9,8 +10,8 @@ namespace DocoptNet.Tests
         public void Should_match_arg()
         {
             Assert.AreEqual(
-                new MatchResult(true, new LeafPattern[0], new LeafPattern[] {new Argument("N", new ValueObject(9))}),
-                new Argument("N").Match(new LeafPattern[] {new Argument(null, new ValueObject(9))})
+                new MatchResult(true, Leaves(), Leaves(new Argument("N", new ValueObject(9)))),
+                new Argument("N").Match(new Argument(null, new ValueObject(9)))
                 );
         }
 
@@ -18,8 +19,8 @@ namespace DocoptNet.Tests
         public void Should_not_match_arg()
         {
             Assert.AreEqual(
-                new MatchResult(false, new LeafPattern[] {new Option("-x")}, new LeafPattern[0]),
-                new Argument("N").Match(new LeafPattern[] {new Option("-x")})
+                new MatchResult(false, Leaves(new Option("-x")), Leaves()),
+                new Argument("N").Match(new Option("-x"))
                 );
         }
 
@@ -27,14 +28,11 @@ namespace DocoptNet.Tests
         public void Should_match_arg_after_opts()
         {
             Assert.AreEqual(
-                new MatchResult(true, new LeafPattern[] {new Option("-x"), new Option("-a")},
-                                new LeafPattern[] {new Argument("N", new ValueObject(5))}),
-                new Argument("N").Match(new LeafPattern[]
-                {
-                    new Option("-x"),
-                    new Option("-a"),
-                    new Argument(null, new ValueObject(5))
-                })
+                new MatchResult(true, Leaves(new Option("-x"), new Option("-a")),
+                                Leaves(new Argument("N", new ValueObject(5)))),
+                new Argument("N").Match(new Option("-x"),
+                                        new Option("-a"),
+                                        new Argument(null, new ValueObject(5)))
                 );
         }
 
@@ -43,10 +41,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                    new LeafPattern[] {new Argument(null, new ValueObject(0))},
-                    new LeafPattern[] {new Argument("N", new ValueObject(9))}),
-                new Argument("N").Match(new LeafPattern[]
-                                            {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(0))})
+                    Leaves(new Argument(null, new ValueObject(0))),
+                    Leaves(new Argument("N", new ValueObject(9)))),
+                new Argument("N").Match(new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(0)))
                 );
         }
     }

--- a/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
+++ b/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -15,9 +16,9 @@ namespace DocoptNet.Tests
             // -a N
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Option("-a"), new Argument("N", "9")}),
-                _pattern.Match(new LeafPattern[] {new Option("-a"), new Argument(null, "9")})
+                                Leaves(),
+                                Leaves(new Option("-a"), new Argument("N", "9"))),
+                _pattern.Match(new Option("-a"), new Argument(null, "9"))
                 );
         }
 
@@ -27,14 +28,10 @@ namespace DocoptNet.Tests
             // -a -x N Z
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[]
-                                    {
-                                        new Option("-a"), new Argument("N", "9"),
-                                        new Option("-x"), new Argument("Z", "5")
-                                    }),
-                _pattern.Match(new LeafPattern[]
-                                   {new Option("-a"), new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
+                                Leaves(),
+                                Leaves(new Option("-a"), new Argument("N", "9"),
+                                       new Option("-x"), new Argument("Z", "5"))),
+                _pattern.Match(new Option("-a"), new Option("-x"), new Argument(null, "9"), new Argument(null, "5"))
                 );
         }
 
@@ -44,13 +41,10 @@ namespace DocoptNet.Tests
             // -x N Z
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[]
-                                    {
-                                        new Option("-x"), new Argument(null, "9"), new Argument(null, "5")
-                                    },
-                                new LeafPattern[0]
+                                Leaves(new Option("-x"), new Argument(null, "9"), new Argument(null, "5")),
+                                Leaves()
                     ),
-                _pattern.Match(new LeafPattern[] {new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
+                _pattern.Match(new Option("-x"), new Argument(null, "9"), new Argument(null, "5"))
                 );
         }
     }

--- a/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
+++ b/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
@@ -15,9 +15,9 @@ namespace DocoptNet.Tests
             // -a N
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Option("-a"), new Argument("N", "9")}),
-                _pattern.Match(new Pattern[] {new Option("-a"), new Argument(null, "9")})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Option("-a"), new Argument("N", "9")}),
+                _pattern.Match(new LeafPattern[] {new Option("-a"), new Argument(null, "9")})
                 );
         }
 
@@ -27,14 +27,14 @@ namespace DocoptNet.Tests
             // -a -x N Z
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[]
+                                new LeafPattern[0],
+                                new LeafPattern[]
                                     {
                                         new Option("-a"), new Argument("N", "9"),
                                         new Option("-x"), new Argument("Z", "5")
                                     }),
-                _pattern.Match(new Pattern[]
-                    {new Option("-a"), new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
+                _pattern.Match(new LeafPattern[]
+                                   {new Option("-a"), new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
                 );
         }
 
@@ -44,13 +44,13 @@ namespace DocoptNet.Tests
             // -x N Z
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[]
+                                new LeafPattern[]
                                     {
                                         new Option("-x"), new Argument(null, "9"), new Argument(null, "5")
                                     },
-                                new Pattern[0]
+                                new LeafPattern[0]
                     ),
-                _pattern.Match(new Pattern[] {new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
+                _pattern.Match(new LeafPattern[] {new Option("-x"), new Argument(null, "9"), new Argument(null, "5")})
                 );
         }
     }

--- a/src/DocoptNet.Tests/CommandMatchTests.cs
+++ b/src/DocoptNet.Tests/CommandMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Command("c", new ValueObject(true))}),
-                new Command("c").Match(new Pattern[] {new Argument(null, new ValueObject("c"))})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Command("c", new ValueObject(true))}),
+                new Command("c").Match(new LeafPattern[] {new Argument(null, new ValueObject("c"))})
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[0]),
-                new Command("c").Match(new Pattern[] {new Option("-x")})
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[0]),
+                new Command("c").Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -32,9 +32,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] { new Option("-x"), new Option("-a") },
-                                new Pattern[] { new Command("c", new ValueObject(true)) }),
-                new Command("c").Match(new Pattern[] { new Option("-x"), new Option("-a"), new Argument(null, new ValueObject("c"))   })
+                                new LeafPattern[] { new Option("-x"), new Option("-a") },
+                                new LeafPattern[] { new Command("c", new ValueObject(true)) }),
+                new Command("c").Match(new LeafPattern[] { new Option("-x"), new Option("-a"), new Argument(null, new ValueObject("c"))   })
                 );
         }
 
@@ -43,9 +43,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Command("rm", new ValueObject(true)) }),
-                new Either(new Command("add"), new Command("rm")).Match(new Pattern[] { new Argument(null, new ValueObject("rm")) })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Command("rm", new ValueObject(true)) }),
+                new Either(new Command("add"), new Command("rm")).Match(new LeafPattern[] { new Argument(null, new ValueObject("rm")) })
                 );
         }
 

--- a/src/DocoptNet.Tests/CommandMatchTests.cs
+++ b/src/DocoptNet.Tests/CommandMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Command("c", new ValueObject(true))}),
-                new Command("c").Match(new LeafPattern[] {new Argument(null, new ValueObject("c"))})
+                                Leaves(),
+                                Leaves(new Command("c", new ValueObject(true)))),
+                new Command("c").Match(new Argument(null, new ValueObject("c")))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[0]),
-                new Command("c").Match(new LeafPattern[] {new Option("-x")})
+                                Leaves(new Option("-x")),
+                                Leaves()),
+                new Command("c").Match(new Option("-x"))
                 );
         }
 
@@ -32,9 +33,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] { new Option("-x"), new Option("-a") },
-                                new LeafPattern[] { new Command("c", new ValueObject(true)) }),
-                new Command("c").Match(new LeafPattern[] { new Option("-x"), new Option("-a"), new Argument(null, new ValueObject("c"))   })
+                                Leaves(new Option("-x"), new Option("-a") ),
+                                Leaves(new Command("c", new ValueObject(true)) )),
+                new Command("c").Match(new Option("-x"), new Option("-a"), new Argument(null, new ValueObject("c")))
                 );
         }
 
@@ -43,9 +44,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Command("rm", new ValueObject(true)) }),
-                new Either(new Command("add"), new Command("rm")).Match(new LeafPattern[] { new Argument(null, new ValueObject("rm")) })
+                                Leaves(),
+                                Leaves(new Command("rm", new ValueObject(true)) )),
+                new Either(new Command("add"), new Command("rm")).Match(new Argument(null, new ValueObject("rm")))
                 );
         }
 

--- a/src/DocoptNet.Tests/EitherMatchTests.cs
+++ b/src/DocoptNet.Tests/EitherMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Option("-a") }),
-                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a") })
+                                Leaves(),
+                                Leaves(new Option("-a") )),
+                new Either(new Option("-a"), new Option("-b")).Match(new Option("-a"))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] { new Option("-b") },
-                                new LeafPattern[] { new Option("-a") }),
-                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a"), new Option("-b"),  })
+                                Leaves(new Option("-b") ),
+                                Leaves(new Option("-a") )),
+                new Either(new Option("-a"), new Option("-b")).Match(new Option("-a"), new Option("-b"))
                 );
         }
 
@@ -32,9 +33,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] { new Option("-x") },
-                                new LeafPattern[0]),
-                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-x") })
+                                Leaves(new Option("-x") ),
+                                Leaves()),
+                new Either(new Option("-a"), new Option("-b")).Match(new Option("-x"))
                 );
         }
 
@@ -43,9 +44,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] { new Option("-x") },
-                                new LeafPattern[] { new Option("-b") }),
-                new Either(new Option("-a"), new Option("-b"), new Option("-c")).Match(new LeafPattern[] { new Option("-x"), new Option("-b") })
+                                Leaves(new Option("-x") ),
+                                Leaves(new Option("-b") )),
+                new Either(new Option("-a"), new Option("-b"), new Option("-c")).Match(new Option("-x"), new Option("-b"))
                 );
         }
 
@@ -54,9 +55,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", 1), new Argument("M", 2) }),
-                new Either(new Argument("M"), new Required(new Argument("N"), new Argument("M"))).Match(new LeafPattern[] { new Argument(null, 1), new Argument(null, 2) })
+                                Leaves(),
+                                Leaves(new Argument("N", 1), new Argument("M", 2) )),
+                new Either(new Argument("M"), new Required(new Argument("N"), new Argument("M"))).Match(new Argument(null, 1), new Argument(null, 2))
                 );
         }
 

--- a/src/DocoptNet.Tests/EitherMatchTests.cs
+++ b/src/DocoptNet.Tests/EitherMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Option("-a") }),
-                new Either(new Option("-a"), new Option("-b")).Match(new Pattern[] { new Option("-a") })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Option("-a") }),
+                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a") })
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] { new Option("-b") },
-                                new Pattern[] { new Option("-a") }),
-                new Either(new Option("-a"), new Option("-b")).Match(new Pattern[] { new Option("-a"), new Option("-b"),  })
+                                new LeafPattern[] { new Option("-b") },
+                                new LeafPattern[] { new Option("-a") }),
+                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a"), new Option("-b"),  })
                 );
         }
 
@@ -32,9 +32,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] { new Option("-x") },
-                                new Pattern[0]),
-                new Either(new Option("-a"), new Option("-b")).Match(new Pattern[] { new Option("-x") })
+                                new LeafPattern[] { new Option("-x") },
+                                new LeafPattern[0]),
+                new Either(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-x") })
                 );
         }
 
@@ -43,9 +43,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] { new Option("-x") },
-                                new Pattern[] { new Option("-b") }),
-                new Either(new Option("-a"), new Option("-b"), new Option("-c")).Match(new Pattern[] { new Option("-x"), new Option("-b") })
+                                new LeafPattern[] { new Option("-x") },
+                                new LeafPattern[] { new Option("-b") }),
+                new Either(new Option("-a"), new Option("-b"), new Option("-c")).Match(new LeafPattern[] { new Option("-x"), new Option("-b") })
                 );
         }
 
@@ -54,9 +54,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", 1), new Argument("M", 2) }),
-                new Either(new Argument("M"), new Required(new Argument("N"), new Argument("M"))).Match(new Pattern[] { new Argument(null, 1), new Argument(null, 2) })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", 1), new Argument("M", 2) }),
+                new Either(new Argument("M"), new Required(new Argument("N"), new Argument("M"))).Match(new LeafPattern[] { new Argument(null, 1), new Argument(null, 2) })
                 );
         }
 

--- a/src/DocoptNet.Tests/Extensions.cs
+++ b/src/DocoptNet.Tests/Extensions.cs
@@ -1,0 +1,10 @@
+namespace DocoptNet.Tests
+{
+    static class Extensions
+    {
+        public static MatchResult Match(this Pattern pattern, params LeafPattern[] left)
+        {
+            return pattern.Match(left);
+        }
+    }
+}

--- a/src/DocoptNet.Tests/ListArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ListArgumentMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", new [] { "1", "2"}) }),
-                new Required(new Argument("N"), new Argument("N")).Fix().Match(new Pattern[] { new Argument(null, "1"), new Argument(null, "2") })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", new [] { "1", "2"}) }),
+                new Required(new Argument("N"), new Argument("N")).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2") })
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
-                new OneOrMore(new Argument("N")).Fix().Match(new Pattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
+                new OneOrMore(new Argument("N")).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
                 );
         }
 
@@ -32,9 +32,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
-                    new Required(new Argument("N"), new OneOrMore(new Argument("N"))).Fix().Match(new Pattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
+                    new Required(new Argument("N"), new OneOrMore(new Argument("N"))).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
                 );
         }
 
@@ -43,9 +43,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", new[] { "1", "2" }) }),
-                    new Required(new Argument("N"), new Required(new Argument("N"))).Fix().Match(new Pattern[] { new Argument(null, "1"), new Argument(null, "2")})
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", new[] { "1", "2" }) }),
+                    new Required(new Argument("N"), new Required(new Argument("N"))).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2")})
                 );
         }
     }

--- a/src/DocoptNet.Tests/ListArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ListArgumentMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", new [] { "1", "2"}) }),
-                new Required(new Argument("N"), new Argument("N")).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2") })
+                                Leaves(),
+                                Leaves(new Argument("N", new [] { "1", "2"}) )),
+                new Required(new Argument("N"), new Argument("N")).Fix().Match(new Argument(null, "1"), new Argument(null, "2"))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
-                new OneOrMore(new Argument("N")).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
+                                Leaves(),
+                                Leaves(new Argument("N", new[] { "1", "2", "3" }) )),
+                new OneOrMore(new Argument("N")).Fix().Match(new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3"))
                 );
         }
 
@@ -32,9 +33,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", new[] { "1", "2", "3" }) }),
-                    new Required(new Argument("N"), new OneOrMore(new Argument("N"))).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3") })
+                                Leaves(),
+                                Leaves(new Argument("N", new[] { "1", "2", "3" }) )),
+                    new Required(new Argument("N"), new OneOrMore(new Argument("N"))).Fix().Match(new Argument(null, "1"), new Argument(null, "2"), new Argument(null, "3"))
                 );
         }
 
@@ -43,9 +44,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", new[] { "1", "2" }) }),
-                    new Required(new Argument("N"), new Required(new Argument("N"))).Fix().Match(new LeafPattern[] { new Argument(null, "1"), new Argument(null, "2")})
+                                Leaves(),
+                                Leaves(new Argument("N", new[] { "1", "2" }) )),
+                    new Required(new Argument("N"), new Required(new Argument("N"))).Fix().Match(new Argument(null, "1"), new Argument(null, "2"))
                 );
         }
     }

--- a/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
+++ b/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Argument("N", new ValueObject(9))}),
-                new OneOrMore(new Argument("N")).Match(new Pattern[] {new Argument(null, new ValueObject(9))})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Argument("N", new ValueObject(9))}),
+                new OneOrMore(new Argument("N")).Match(new LeafPattern[] {new Argument(null, new ValueObject(9))})
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[0],
-                                new Pattern[0]),
-                new OneOrMore(new Argument("N")).Match(new Pattern[0])
+                                new LeafPattern[0],
+                                new LeafPattern[0]),
+                new OneOrMore(new Argument("N")).Match(new LeafPattern[0])
                 );
         }
 
@@ -32,10 +32,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[0]
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[0]
                     ),
-                new OneOrMore(new Argument("N")).Match(new Pattern[] {new Option("-x")})
+                new OneOrMore(new Argument("N")).Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -44,11 +44,11 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[]
+                                new LeafPattern[0],
+                                new LeafPattern[]
                                     {new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8))}),
-                new OneOrMore(new Argument("N")).Match(new Pattern[]
-                    {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(8))})
+                new OneOrMore(new Argument("N")).Match(new LeafPattern[]
+                                                           {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(8))})
                 );
         }
 
@@ -57,11 +57,11 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[]
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[]
                                     {new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8))}),
-                new OneOrMore(new Argument("N")).Match(new Pattern[]
-                    {new Argument(null, new ValueObject(9)), new Option("-x"), new Argument(null, new ValueObject(8))})
+                new OneOrMore(new Argument("N")).Match(new LeafPattern[]
+                                                           {new Argument(null, new ValueObject(9)), new Option("-x"), new Argument(null, new ValueObject(8))})
                 );
         }
 
@@ -70,11 +70,11 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] {new Argument(null, new ValueObject(8))},
-                                new Pattern[] {new Option("-a"), new Option("-a")}
+                                new LeafPattern[] {new Argument(null, new ValueObject(8))},
+                                new LeafPattern[] {new Option("-a"), new Option("-a")}
                     ),
-                new OneOrMore(new Option("-a")).Match(new Pattern[]
-                    {new Option("-a"), new Argument(null, new ValueObject(8)), new Option("-a")})
+                new OneOrMore(new Option("-a")).Match(new LeafPattern[]
+                                                          {new Option("-a"), new Argument(null, new ValueObject(8)), new Option("-a")})
                 );
         }
 
@@ -83,10 +83,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] {new Argument(null, new ValueObject(98)), new Option("-x")},
-                                new Pattern[0]),
-                new OneOrMore(new Option("-a")).Match(new Pattern[]
-                    {new Argument(null, new ValueObject(98)), new Option("-x")})
+                                new LeafPattern[] {new Argument(null, new ValueObject(98)), new Option("-x")},
+                                new LeafPattern[0]),
+                new OneOrMore(new Option("-a")).Match(new LeafPattern[]
+                                                          {new Argument(null, new ValueObject(98)), new Option("-x")})
                 );
         }
 
@@ -95,19 +95,19 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[]
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[]
                                     {
                                         new Option("-a"), new Argument("N", new ValueObject(1)),
                                         new Option("-a"), new Argument("N", new ValueObject(2))
                                     }
                     ),
-                new OneOrMore(new Required(new Option("-a"), new Argument("N"))).Match(new Pattern[]
-                    {
-                        new Option("-a"), new Argument(null, new ValueObject(1)),
-                        new Option("-x"),
-                        new Option("-a"), new Argument(null, new ValueObject(2))
-                    })
+                new OneOrMore(new Required(new Option("-a"), new Argument("N"))).Match(new LeafPattern[]
+                {
+                    new Option("-a"), new Argument(null, new ValueObject(1)),
+                    new Option("-x"),
+                    new Option("-a"), new Argument(null, new ValueObject(2))
+                })
                 );
         }
 
@@ -116,10 +116,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Argument("N", new ValueObject(9))}
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Argument("N", new ValueObject(9))}
                     ),
-                new OneOrMore(new Optional(new Argument("N"))).Match(new Pattern[]
+                new OneOrMore(new Optional(new Argument("N"))).Match(new LeafPattern[]
                     {new Argument(null, new ValueObject(9))})
                 );
         }

--- a/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
+++ b/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Argument("N", new ValueObject(9))}),
-                new OneOrMore(new Argument("N")).Match(new LeafPattern[] {new Argument(null, new ValueObject(9))})
+                                Leaves(),
+                                Leaves(new Argument("N", new ValueObject(9)))),
+                new OneOrMore(new Argument("N")).Match(new Argument(null, new ValueObject(9)))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[0],
-                                new LeafPattern[0]),
-                new OneOrMore(new Argument("N")).Match(new LeafPattern[0])
+                                Leaves(),
+                                Leaves()),
+                new OneOrMore(new Argument("N")).Match()
                 );
         }
 
@@ -32,10 +33,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[0]
+                                Leaves(new Option("-x")),
+                                Leaves()
                     ),
-                new OneOrMore(new Argument("N")).Match(new LeafPattern[] {new Option("-x")})
+                new OneOrMore(new Argument("N")).Match(new Option("-x"))
                 );
         }
 
@@ -44,11 +45,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[]
-                                    {new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8))}),
-                new OneOrMore(new Argument("N")).Match(new LeafPattern[]
-                                                           {new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(8))})
+                                Leaves(),
+                                Leaves(new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8)))),
+                new OneOrMore(new Argument("N")).Match(new Argument(null, new ValueObject(9)), new Argument(null, new ValueObject(8)))
                 );
         }
 
@@ -57,11 +56,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[]
-                                    {new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8))}),
-                new OneOrMore(new Argument("N")).Match(new LeafPattern[]
-                                                           {new Argument(null, new ValueObject(9)), new Option("-x"), new Argument(null, new ValueObject(8))})
+                                Leaves(new Option("-x")),
+                                Leaves(new Argument("N", new ValueObject(9)), new Argument("N", new ValueObject(8)))),
+                new OneOrMore(new Argument("N")).Match(new Argument(null, new ValueObject(9)), new Option("-x"), new Argument(null, new ValueObject(8)))
                 );
         }
 
@@ -70,11 +67,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] {new Argument(null, new ValueObject(8))},
-                                new LeafPattern[] {new Option("-a"), new Option("-a")}
+                                Leaves(new Argument(null, new ValueObject(8))),
+                                Leaves(new Option("-a"), new Option("-a"))
                     ),
-                new OneOrMore(new Option("-a")).Match(new LeafPattern[]
-                                                          {new Option("-a"), new Argument(null, new ValueObject(8)), new Option("-a")})
+                new OneOrMore(new Option("-a")).Match(new Option("-a"), new Argument(null, new ValueObject(8)), new Option("-a"))
                 );
         }
 
@@ -83,10 +79,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] {new Argument(null, new ValueObject(98)), new Option("-x")},
-                                new LeafPattern[0]),
-                new OneOrMore(new Option("-a")).Match(new LeafPattern[]
-                                                          {new Argument(null, new ValueObject(98)), new Option("-x")})
+                                Leaves(new Argument(null, new ValueObject(98)), new Option("-x")),
+                                Leaves()),
+                new OneOrMore(new Option("-a")).Match(new Argument(null, new ValueObject(98)), new Option("-x"))
                 );
         }
 
@@ -95,19 +90,11 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[]
-                                    {
-                                        new Option("-a"), new Argument("N", new ValueObject(1)),
-                                        new Option("-a"), new Argument("N", new ValueObject(2))
-                                    }
+                                Leaves(new Option("-x")),
+                                Leaves(new Option("-a"), new Argument("N", new ValueObject(1)),
+                                       new Option("-a"), new Argument("N", new ValueObject(2)))
                     ),
-                new OneOrMore(new Required(new Option("-a"), new Argument("N"))).Match(new LeafPattern[]
-                {
-                    new Option("-a"), new Argument(null, new ValueObject(1)),
-                    new Option("-x"),
-                    new Option("-a"), new Argument(null, new ValueObject(2))
-                })
+                new OneOrMore(new Required(new Option("-a"), new Argument("N"))).Match(new Option("-a"), new Argument(null, new ValueObject(1)), new Option("-x"), new Option("-a"), new Argument(null, new ValueObject(2)))
                 );
         }
 
@@ -116,11 +103,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Argument("N", new ValueObject(9))}
+                                Leaves(),
+                                Leaves(new Argument("N", new ValueObject(9)))
                     ),
-                new OneOrMore(new Optional(new Argument("N"))).Match(new LeafPattern[]
-                    {new Argument(null, new ValueObject(9))})
+                new OneOrMore(new Optional(new Argument("N"))).Match(new Argument(null, new ValueObject(9)))
                 );
         }
     }

--- a/src/DocoptNet.Tests/OptionMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -8,24 +9,24 @@ namespace DocoptNet.Tests
         [Test]
         public void Test_option_match_opt_matched()
         {
-            var expected = new MatchResult(true, new LeafPattern[0], new[] {new Option("-a", value: new ValueObject(true))});
-            var actual = new Option("-a").Match(new[] {new Option("-a", value: new ValueObject(true))});
+            var expected = new MatchResult(true, Leaves(), Leaves(new Option("-a", value: new ValueObject(true))));
+            var actual = new Option("-a").Match(new Option("-a", value: new ValueObject(true)));
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
         public void Test_option_match_opt_no_match()
         {
-            var expected = new MatchResult(false, new[] {new Option("-x")}, new LeafPattern[0]);
-            var actual = new Option("-a").Match(new[] {new Option("-x")});
+            var expected = new MatchResult(false, Leaves(new Option("-x")), Leaves());
+            var actual = new Option("-a").Match(new Option("-x"));
             Assert.AreEqual(expected, actual);
         }
 
         [Test]
         public void Test_option_match_opt_no_match_with_arg()
         {
-            var expected = new MatchResult(false, new[] {new Argument("N"),}, new LeafPattern[0]);
-            var actual = new Option("-a").Match(new[] {new Argument("N")});
+            var expected = new MatchResult(false, Leaves(new Argument("N")), Leaves());
+            var actual = new Option("-a").Match(new Argument("N"));
             Assert.AreEqual(expected, actual);
         }
 
@@ -33,10 +34,10 @@ namespace DocoptNet.Tests
         public void Test_option_match_one_opt_out_of_two()
         {
             var expected = new MatchResult(true,
-                                           new LeafPattern[] {new Option("-x"), new Argument("N")},
-                                           new[] {new Option("-a")}
+                                           Leaves(new Option("-x"), new Argument("N")),
+                                           Leaves(new Option("-a"))
                 );
-            var actual = new Option("-a").Match(new LeafPattern[] {new Option("-x"), new Option("-a"), new Argument("N")});
+            var actual = new Option("-a").Match(new Option("-x"), new Option("-a"), new Argument("N"));
             Assert.AreEqual(expected, actual);
         }
 
@@ -44,11 +45,11 @@ namespace DocoptNet.Tests
         public void Test_option_match_same_opt_one_with_value()
         {
             var expected = new MatchResult(true,
-                                           new LeafPattern[] {new Option("-a")},
-                                           new LeafPattern[] {new Option("-a", value: new ValueObject(true))}
+                                           Leaves(new Option("-a")),
+                                           Leaves(new Option("-a", value: new ValueObject(true)))
                 );
             var actual =
-                new Option("-a").Match(new LeafPattern[] { new Option("-a", value: new ValueObject(true)), new Option("-a") });
+                new Option("-a").Match(new Option("-a", value: new ValueObject(true)), new Option("-a"));
             Assert.AreEqual(expected, actual);
         }
     }

--- a/src/DocoptNet.Tests/OptionMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionMatchTests.cs
@@ -8,7 +8,7 @@ namespace DocoptNet.Tests
         [Test]
         public void Test_option_match_opt_matched()
         {
-            var expected = new MatchResult(true, new Pattern[0], new[] {new Option("-a", value: new ValueObject(true))});
+            var expected = new MatchResult(true, new LeafPattern[0], new[] {new Option("-a", value: new ValueObject(true))});
             var actual = new Option("-a").Match(new[] {new Option("-a", value: new ValueObject(true))});
             Assert.AreEqual(expected, actual);
         }
@@ -16,7 +16,7 @@ namespace DocoptNet.Tests
         [Test]
         public void Test_option_match_opt_no_match()
         {
-            var expected = new MatchResult(false, new[] {new Option("-x")}, new Pattern[0]);
+            var expected = new MatchResult(false, new[] {new Option("-x")}, new LeafPattern[0]);
             var actual = new Option("-a").Match(new[] {new Option("-x")});
             Assert.AreEqual(expected, actual);
         }
@@ -24,7 +24,7 @@ namespace DocoptNet.Tests
         [Test]
         public void Test_option_match_opt_no_match_with_arg()
         {
-            var expected = new MatchResult(false, new[] {new Argument("N"),}, new Pattern[0]);
+            var expected = new MatchResult(false, new[] {new Argument("N"),}, new LeafPattern[0]);
             var actual = new Option("-a").Match(new[] {new Argument("N")});
             Assert.AreEqual(expected, actual);
         }
@@ -33,10 +33,10 @@ namespace DocoptNet.Tests
         public void Test_option_match_one_opt_out_of_two()
         {
             var expected = new MatchResult(true,
-                                           new Pattern[] {new Option("-x"), new Argument("N")},
+                                           new LeafPattern[] {new Option("-x"), new Argument("N")},
                                            new[] {new Option("-a")}
                 );
-            var actual = new Option("-a").Match(new Pattern[] {new Option("-x"), new Option("-a"), new Argument("N")});
+            var actual = new Option("-a").Match(new LeafPattern[] {new Option("-x"), new Option("-a"), new Argument("N")});
             Assert.AreEqual(expected, actual);
         }
 
@@ -44,11 +44,11 @@ namespace DocoptNet.Tests
         public void Test_option_match_same_opt_one_with_value()
         {
             var expected = new MatchResult(true,
-                                           new Pattern[] {new Option("-a")},
-                                           new Pattern[] {new Option("-a", value: new ValueObject(true))}
+                                           new LeafPattern[] {new Option("-a")},
+                                           new LeafPattern[] {new Option("-a", value: new ValueObject(true))}
                 );
             var actual =
-                new Option("-a").Match(new Pattern[] { new Option("-a", value: new ValueObject(true)), new Option("-a") });
+                new Option("-a").Match(new LeafPattern[] { new Option("-a", value: new ValueObject(true)), new Option("-a") });
             Assert.AreEqual(expected, actual);
         }
     }

--- a/src/DocoptNet.Tests/OptionalMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionalMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Option("-a")}),
-                new Optional(new Option("-a")).Match(new Pattern[] {new Option("-a")})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Option("-a")}),
+                new Optional(new Option("-a")).Match(new LeafPattern[] {new Option("-a")})
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[0]),
-                new Optional(new Option("-a")).Match(new Pattern[0])
+                                new LeafPattern[0],
+                                new LeafPattern[0]),
+                new Optional(new Option("-a")).Match(new LeafPattern[0])
                 );
         }
 
@@ -32,10 +32,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[0]
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[0]
                     ),
-                new Optional(new Option("-a")).Match(new Pattern[] {new Option("-x")})
+                new Optional(new Option("-a")).Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -44,9 +44,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Option("-a")}),
-                new Optional(new Option("-a"), new Option("-b")).Match(new Pattern[] {new Option("-a")})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Option("-a")}),
+                new Optional(new Option("-a"), new Option("-b")).Match(new LeafPattern[] {new Option("-a")})
                 );
         }
 
@@ -55,9 +55,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[0]),
-                new Optional(new Option("-a"), new Option("-b")).Match(new Pattern[] {new Option("-x")})
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[0]),
+                new Optional(new Option("-a"), new Option("-b")).Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -66,9 +66,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] { new Argument("N", new ValueObject(9)) }),
-                new Optional(new Argument("N")).Match(new Pattern[] { new Argument(null, new ValueObject(9))  })
+                                new LeafPattern[0],
+                                new LeafPattern[] { new Argument("N", new ValueObject(9)) }),
+                new Optional(new Argument("N")).Match(new LeafPattern[] { new Argument(null, new ValueObject(9))  })
                 );
         }
 
@@ -77,10 +77,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[] { new Option("-x") },
-                                new Pattern[] { new Option("-a"), new Option("-b") }),
+                                new LeafPattern[] { new Option("-x") },
+                                new LeafPattern[] { new Option("-a"), new Option("-b") }),
                 new Optional(new Option("-a"), new Option("-b")).Match(
-                    new Pattern[] { new Option("-b"), new Option("-x"), new Option("-a") })
+                    new LeafPattern[] { new Option("-b"), new Option("-x"), new Option("-a") })
                 );
         }
     }

--- a/src/DocoptNet.Tests/OptionalMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionalMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Option("-a")}),
-                new Optional(new Option("-a")).Match(new LeafPattern[] {new Option("-a")})
+                                Leaves(),
+                                Leaves(new Option("-a"))),
+                new Optional(new Option("-a")).Match(new Option("-a"))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[0]),
-                new Optional(new Option("-a")).Match(new LeafPattern[0])
+                                Leaves(),
+                                Leaves()),
+                new Optional(new Option("-a")).Match()
                 );
         }
 
@@ -32,10 +33,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[0]
+                                Leaves(new Option("-x")),
+                                Leaves()
                     ),
-                new Optional(new Option("-a")).Match(new LeafPattern[] {new Option("-x")})
+                new Optional(new Option("-a")).Match(new Option("-x"))
                 );
         }
 
@@ -44,9 +45,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Option("-a")}),
-                new Optional(new Option("-a"), new Option("-b")).Match(new LeafPattern[] {new Option("-a")})
+                                Leaves(),
+                                Leaves(new Option("-a"))),
+                new Optional(new Option("-a"), new Option("-b")).Match(new Option("-a"))
                 );
         }
 
@@ -55,9 +56,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[0]),
-                new Optional(new Option("-a"), new Option("-b")).Match(new LeafPattern[] {new Option("-x")})
+                                Leaves(new Option("-x")),
+                                Leaves()),
+                new Optional(new Option("-a"), new Option("-b")).Match(new Option("-x"))
                 );
         }
 
@@ -66,9 +67,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] { new Argument("N", new ValueObject(9)) }),
-                new Optional(new Argument("N")).Match(new LeafPattern[] { new Argument(null, new ValueObject(9))  })
+                                Leaves(),
+                                Leaves(new Argument("N", new ValueObject(9)) )),
+                new Optional(new Argument("N")).Match(new Argument(null, new ValueObject(9)))
                 );
         }
 
@@ -77,10 +78,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[] { new Option("-x") },
-                                new LeafPattern[] { new Option("-a"), new Option("-b") }),
-                new Optional(new Option("-a"), new Option("-b")).Match(
-                    new LeafPattern[] { new Option("-b"), new Option("-x"), new Option("-a") })
+                                Leaves(new Option("-x") ),
+                                Leaves(new Option("-a"), new Option("-b") )),
+                new Optional(new Option("-a"), new Option("-b")).Match(new Option("-b"), new Option("-x"), new Option("-a"))
                 );
         }
     }

--- a/src/DocoptNet.Tests/PatternFactory.cs
+++ b/src/DocoptNet.Tests/PatternFactory.cs
@@ -1,0 +1,10 @@
+namespace DocoptNet.Tests
+{
+    static class PatternFactory
+    {
+        static readonly LeafPattern[] ZeroLeaves = new LeafPattern[0];
+
+        public static LeafPattern[] Leaves() => ZeroLeaves;
+        public static LeafPattern[] Leaves(params LeafPattern[] leaves) => leaves;
+    }
+}

--- a/src/DocoptNet.Tests/RequiredMatchTests.cs
+++ b/src/DocoptNet.Tests/RequiredMatchTests.cs
@@ -10,9 +10,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new Pattern[0],
-                                new Pattern[] {new Option("-a")}),
-                new Required(new Option("-a")).Match(new Pattern[] {new Option("-a")})
+                                new LeafPattern[0],
+                                new LeafPattern[] {new Option("-a")}),
+                new Required(new Option("-a")).Match(new LeafPattern[] {new Option("-a")})
                 );
         }
 
@@ -21,9 +21,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[0],
-                                new Pattern[0]),
-                new Required(new Option("-a")).Match(new Pattern[0])
+                                new LeafPattern[0],
+                                new LeafPattern[0]),
+                new Required(new Option("-a")).Match(new LeafPattern[0])
                 );
         }
 
@@ -32,10 +32,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] {new Option("-x")},
-                                new Pattern[0]
+                                new LeafPattern[] {new Option("-x")},
+                                new LeafPattern[0]
                     ),
-                new Required(new Option("-a")).Match(new Pattern[] {new Option("-x")})
+                new Required(new Option("-a")).Match(new LeafPattern[] {new Option("-x")})
                 );
         }
 
@@ -44,10 +44,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new Pattern[] { new Option("-a") },
-                                new Pattern[0]
+                                new LeafPattern[] { new Option("-a") },
+                                new LeafPattern[0]
                     ),
-                new Required(new Option("-a"), new Option("-b")).Match(new Pattern[] { new Option("-a") })
+                new Required(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a") })
                 );
         }
     }

--- a/src/DocoptNet.Tests/RequiredMatchTests.cs
+++ b/src/DocoptNet.Tests/RequiredMatchTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using static DocoptNet.Tests.PatternFactory;
 
 namespace DocoptNet.Tests
 {
@@ -10,9 +11,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(true,
-                                new LeafPattern[0],
-                                new LeafPattern[] {new Option("-a")}),
-                new Required(new Option("-a")).Match(new LeafPattern[] {new Option("-a")})
+                                Leaves(),
+                                Leaves(new Option("-a"))),
+                new Required(new Option("-a")).Match(new Option("-a"))
                 );
         }
 
@@ -21,9 +22,9 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[0],
-                                new LeafPattern[0]),
-                new Required(new Option("-a")).Match(new LeafPattern[0])
+                                Leaves(),
+                                Leaves()),
+                new Required(new Option("-a")).Match()
                 );
         }
 
@@ -32,10 +33,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] {new Option("-x")},
-                                new LeafPattern[0]
+                                Leaves(new Option("-x")),
+                                Leaves()
                     ),
-                new Required(new Option("-a")).Match(new LeafPattern[] {new Option("-x")})
+                new Required(new Option("-a")).Match(new Option("-x"))
                 );
         }
 
@@ -44,10 +45,10 @@ namespace DocoptNet.Tests
         {
             Assert.AreEqual(
                 new MatchResult(false,
-                                new LeafPattern[] { new Option("-a") },
-                                new LeafPattern[0]
+                                Leaves(new Option("-a")),
+                                Leaves()
                     ),
-                new Required(new Option("-a"), new Option("-b")).Match(new LeafPattern[] { new Option("-a") })
+                new Required(new Option("-a"), new Option("-b")).Match(new Option("-a"))
                 );
         }
     }

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -24,12 +24,12 @@ namespace DocoptNet
         {
         }
 
-        public override (int Index, Pattern Match) SingleMatch(IList<Pattern> left)
+        public override (int Index, LeafPattern Match) SingleMatch(IList<LeafPattern> left)
         {
             for (var i = 0; i < left.Count; i++)
             {
-                if (left[i] is Argument)
-                    return (i, new Argument(Name, left[i].Value));
+                if (left[i] is Argument arg)
+                    return (i, new Argument(Name, arg.Value));
             }
             return default;
         }

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -8,14 +8,13 @@ namespace DocoptNet
         {
         }
 
-        public override (int Index, Pattern Match) SingleMatch(IList<Pattern> left)
+        public override (int Index, LeafPattern Match) SingleMatch(IList<LeafPattern> left)
         {
             for (var i = 0; i < left.Count; i++)
             {
-                var pattern = left[i];
-                if (pattern is Argument)
+                if (left[i] is Argument arg)
                 {
-                    if (pattern.Value.ToString() == Name)
+                    if (arg.Value.ToString() == Name)
                         return (i, new Command(Name, new ValueObject(true)));
                     break;
                 }

--- a/src/DocoptNet/Either.cs
+++ b/src/DocoptNet/Either.cs
@@ -9,9 +9,10 @@ namespace DocoptNet
         {
         }
 
-        public override MatchResult Match(IList<Pattern> left, IEnumerable<Pattern> collected = null)
+        public override MatchResult Match(IList<LeafPattern> left,
+                                          IEnumerable<LeafPattern> collected = null)
         {
-            var coll = collected ?? new List<Pattern>();
+            var coll = collected ?? new List<LeafPattern>();
             var outcomes =
                 Children.Select(pattern => pattern.Match(left, coll))
                         .Where(outcome => outcome.Matched)

--- a/src/DocoptNet/LeafPattern.cs
+++ b/src/DocoptNet/LeafPattern.cs
@@ -26,6 +26,8 @@ namespace DocoptNet
             get { return _name; }
         }
 
+        public ValueObject Value { get; set; }
+
         public override ICollection<Pattern> Flat(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException(nameof(types));
@@ -36,20 +38,21 @@ namespace DocoptNet
             return new Pattern[] {};
         }
 
-        public virtual (int Index, Pattern Match) SingleMatch(IList<Pattern> patterns)
+        public virtual (int Index, LeafPattern Match) SingleMatch(IList<LeafPattern> patterns)
         {
             return default;
         }
 
-        public override MatchResult Match(IList<Pattern> left, IEnumerable<Pattern> collected = null)
+        public override MatchResult Match(IList<LeafPattern> left,
+                                          IEnumerable<LeafPattern> collected = null)
         {
-            var coll = collected ?? new List<Pattern>();
+            var coll = collected ?? new List<LeafPattern>();
             var (index, match) = SingleMatch(left);
             if (match == null)
             {
                 return new MatchResult(false, left, coll);
             }
-            var left_ = new List<Pattern>();
+            var left_ = new List<LeafPattern>();
             left_.AddRange(left.Take(index));
             left_.AddRange(left.Skip(index + 1));
             var sameName = coll.Where(a => a.Name == Name).ToList();
@@ -63,13 +66,13 @@ namespace DocoptNet
                 if (sameName.Count == 0)
                 {
                     match.Value = increment;
-                    var res = new List<Pattern>(coll) {match};
+                    var res = new List<LeafPattern>(coll) {match};
                     return new MatchResult(true, left_, res);
                 }
                 sameName[0].Value.Add(increment);
                 return new MatchResult(true, left_, coll);
             }
-            var resColl = new List<Pattern>();
+            var resColl = new List<LeafPattern>();
             resColl.AddRange(coll);
             resColl.Add(match);
             return new MatchResult(true, left_, resColl);

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -6,12 +6,12 @@ namespace DocoptNet
     internal class MatchResult
     {
         public bool Matched;
-        public IList<Pattern> Left;
-        public IEnumerable<Pattern> Collected;
+        public IList<LeafPattern> Left;
+        public IEnumerable<LeafPattern> Collected;
 
         public MatchResult() { }
 
-        public MatchResult(bool matched, IList<Pattern> left, IEnumerable<Pattern> collected)
+        public MatchResult(bool matched, IList<LeafPattern> left, IEnumerable<LeafPattern> collected)
         {
             Matched = matched;
             Left = left;
@@ -49,7 +49,7 @@ namespace DocoptNet
             );
         }
 
-        public void Deconstruct(out bool matched, out IList<Pattern> left, out IEnumerable<Pattern> collected)
+        public void Deconstruct(out bool matched, out IList<LeafPattern> left, out IEnumerable<LeafPattern> collected)
         {
             (matched, left, collected) = (Matched, Left, Collected);
         }

--- a/src/DocoptNet/OneOrMore.cs
+++ b/src/DocoptNet/OneOrMore.cs
@@ -10,13 +10,14 @@ namespace DocoptNet
         {
         }
 
-        public override MatchResult Match(IList<Pattern> left, IEnumerable<Pattern> collected = null)
+        public override MatchResult Match(IList<LeafPattern> left,
+                                          IEnumerable<LeafPattern> collected = null)
         {
             Debug.Assert(Children.Count == 1);
-            var coll = collected ?? new List<Pattern>();
+            var coll = collected ?? new List<LeafPattern>();
             var l = left;
             var c = coll;
-            IList<Pattern> l_ = null;
+            IList<LeafPattern> l_ = null;
             var matched = true;
             var times = 0;
             while (matched)

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -48,7 +48,7 @@ namespace DocoptNet
             return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? {2} : _args[\"{1}\"].ToString(); }} }}", s, Name, defaultValue);
         }
 
-        public override (int Index, Pattern Match) SingleMatch(IList<Pattern> left)
+        public override (int Index, LeafPattern Match) SingleMatch(IList<LeafPattern> left)
         {
             for (var i = 0; i < left.Count; i++)
             {

--- a/src/DocoptNet/Optional.cs
+++ b/src/DocoptNet/Optional.cs
@@ -9,9 +9,10 @@ namespace DocoptNet
 
         }
 
-        public override MatchResult Match(IList<Pattern> left, IEnumerable<Pattern> collected = null)
+        public override MatchResult Match(IList<LeafPattern> left,
+                                          IEnumerable<LeafPattern> collected = null)
         {
-            var c = collected ?? new List<Pattern>();
+            var c = collected ?? new List<LeafPattern>();
             var l = left;
             foreach (var pattern in Children)
             {

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -8,8 +8,6 @@ namespace DocoptNet
 {
     internal abstract class Pattern
     {
-        public ValueObject Value { get; set; }
-
         public virtual string Name
         {
             get { return ToString(); }
@@ -94,7 +92,7 @@ namespace DocoptNet
                 var cx = aCase.ToList();
                 var l = aCase.Where(e => cx.Count(c2 => c2.Equals(e)) > 1).ToList();
 
-                foreach (var e in l)
+                foreach (var e in l.OfType<LeafPattern>())
                 {
                     if (e is Argument || e is Option { ArgCount: > 0 })
                     {
@@ -175,7 +173,8 @@ namespace DocoptNet
             return new Either(result.Select(r => new Required(r.ToArray()) as Pattern).ToArray());
         }
 
-        public virtual MatchResult Match(IList<Pattern> left, IEnumerable<Pattern> collected = null)
+        public virtual MatchResult Match(IList<LeafPattern> left,
+                                         IEnumerable<LeafPattern> collected = null)
         {
             return new MatchResult();
         }

--- a/src/DocoptNet/Required.cs
+++ b/src/DocoptNet/Required.cs
@@ -9,10 +9,10 @@ namespace DocoptNet
         {
         }
 
-        public override MatchResult Match(IList<Pattern> left,
-                                          IEnumerable<Pattern> collected = null)
+        public override MatchResult Match(IList<LeafPattern> left,
+                                          IEnumerable<LeafPattern> collected = null)
         {
-            var coll = collected ?? new List<Pattern>();
+            var coll = collected ?? new List<LeafPattern>();
             var l = left;
             var c = coll;
             foreach (var pattern in Children)


### PR DESCRIPTION
It seemed odd to have `Value` at the level of the `Pattern` abstract since only leaf patterns can have a value. This PR therefore moves `Value` to `LeafPattern` and its subclasses (`Command`, `Option` & `Argument`). It reveals more honest signatures and types, e.g. for `Match`, `MatchResult`, `SingleMatch`, `Extras`, `ParseArgv`, `ParseShorts`, `ParseLong` and so on.

I also introduced some helpers to makes matching of leaf patterns more discoverable and readable in tests, though this could be subject so happy to revert the helpers from 084ad5a3304c3dc498d1db3f4001ec151403fa9f if there's a strong argument against their value.