### PR TITLE
Only pack projects that opt-in

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
     <LangVersion>9</LangVersion>
     <Nullable>warnings</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -16,6 +16,7 @@
     <AssemblyOriginatorKeyFile>DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <IsPackable>true</IsPackable>
     <PackageId>DocoptNet</PackageId>
     <Copyright>Copyright (c) 2013 Dinh Doan Van Bien, dinh@doanvanbien.com</Copyright>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>


### PR DESCRIPTION
`dotnet pack` was packaging too many projects:

    Successfully created package 'C:\projects\docopt-net\src\DocoptNet\bin\Release\docopt.net.0.6.1.11.nupkg'.
    Successfully created package 'C:\projects\docopt-net\src\Testee\bin\Release\Testee.1.0.0.nupkg'.
    Successfully created package 'C:\projects\docopt-net\src\Examples\NavalFate\bin\Release\NavalFate.1.0.0.nupkg'.
    Successfully created package 'C:\projects\docopt-net\src\T4DocoptNetHostApp\bin\Release\T4DocoptNetHostApp.1.0.0.nupkg'.

This PR introduces an opt-in policy by disabling packaging in `Directory.Build.props` and then only enabling it for `Docopt.csproj`.
