### PR TITLE
Move "using" directives inside namespace

### DIFF
--- a/src/DocoptNet.Tests/AnyOptionsParameterTests.cs
+++ b/src/DocoptNet.Tests/AnyOptionsParameterTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class AnyOptionsParameterTests
     {

--- a/src/DocoptNet.Tests/ArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ArgumentMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class ArgumentMatchTests
     {

--- a/src/DocoptNet.Tests/Assumptions.cs
+++ b/src/DocoptNet.Tests/Assumptions.cs
@@ -1,8 +1,8 @@
-using System;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System;
+    using NUnit.Framework;
+
     /// <summary>
     ///     Set of tests to validate assumptions about the BCL or other APIs.
     /// </summary>

--- a/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
+++ b/src/DocoptNet.Tests/BasicPatternMatchingTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class BasicPatternMatchingTests
     {

--- a/src/DocoptNet.Tests/CommandMatchTests.cs
+++ b/src/DocoptNet.Tests/CommandMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class CommandMatchTests
     {

--- a/src/DocoptNet.Tests/CommandsTests.cs
+++ b/src/DocoptNet.Tests/CommandsTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class CommandsTests
     {

--- a/src/DocoptNet.Tests/CountMultipleFlagsTests.cs
+++ b/src/DocoptNet.Tests/CountMultipleFlagsTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class CountMultipleFlagsTests
     {

--- a/src/DocoptNet.Tests/DefaultValueForPositionalArgumentsTests.cs
+++ b/src/DocoptNet.Tests/DefaultValueForPositionalArgumentsTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class DefaultValueForPositionalArgumentsTests
     {

--- a/src/DocoptNet.Tests/DocoptTests.cs
+++ b/src/DocoptNet.Tests/DocoptTests.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
-using System.Linq;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using NUnit.Framework;
+
     [TestFixture]
     public class DocoptTests
     {

--- a/src/DocoptNet.Tests/EitherMatchTests.cs
+++ b/src/DocoptNet.Tests/EitherMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class EitherMatchTests
     {

--- a/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/src/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class GenerateCodeHelperTest
     {

--- a/src/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/src/DocoptNet.Tests/GenerateCodeTests.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Text.RegularExpressions;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System;
+    using System.Text.RegularExpressions;
+    using NUnit.Framework;
+
     [TestFixture]
     public class GenerateCodeTests
     {

--- a/src/DocoptNet.Tests/GetNodesTests.cs
+++ b/src/DocoptNet.Tests/GetNodesTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class GetNodesTests
     {

--- a/src/DocoptNet.Tests/LanguageAgnosticTests.cs
+++ b/src/DocoptNet.Tests/LanguageAgnosticTests.cs
@@ -1,15 +1,15 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using Newtonsoft.Json;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Newtonsoft.Json;
+    using NUnit.Framework;
+
     [TestFixture]
     public class LanguageAgnosticTests
     {

--- a/src/DocoptNet.Tests/ListArgumentMatchTests.cs
+++ b/src/DocoptNet.Tests/ListArgumentMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class ListArgumentMatchTests
     {

--- a/src/DocoptNet.Tests/LongOptionsErrorHandlingTests.cs
+++ b/src/DocoptNet.Tests/LongOptionsErrorHandlingTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class LongOptionsErrorHandlingTests
     {

--- a/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
+++ b/src/DocoptNet.Tests/OneOrMoreMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class OneOrMoreMatchTests
     {

--- a/src/DocoptNet.Tests/OptionMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class OptionMatchTests
     {

--- a/src/DocoptNet.Tests/OptionNameTests.cs
+++ b/src/DocoptNet.Tests/OptionNameTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class OptionNameTests
     {

--- a/src/DocoptNet.Tests/OptionParseTests.cs
+++ b/src/DocoptNet.Tests/OptionParseTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class OptionParseTests
     {

--- a/src/DocoptNet.Tests/OptionalMatchTests.cs
+++ b/src/DocoptNet.Tests/OptionalMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class OptionalMatchTests
     {

--- a/src/DocoptNet.Tests/OptionsFirstTests.cs
+++ b/src/DocoptNet.Tests/OptionsFirstTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class OptionsFirstTests
     {

--- a/src/DocoptNet.Tests/ParseArgvTests.cs
+++ b/src/DocoptNet.Tests/ParseArgvTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class ParseArgvTests
     {

--- a/src/DocoptNet.Tests/ParseDefaultsTests.cs
+++ b/src/DocoptNet.Tests/ParseDefaultsTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class ParseDefaultsTests
     {

--- a/src/DocoptNet.Tests/ParsePatternTests.cs
+++ b/src/DocoptNet.Tests/ParsePatternTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class ParsePatternTests
     {

--- a/src/DocoptNet.Tests/PatterEitherTests.cs
+++ b/src/DocoptNet.Tests/PatterEitherTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class PatterEitherTests
     {

--- a/src/DocoptNet.Tests/PatternFixIdentitiesTests.cs
+++ b/src/DocoptNet.Tests/PatternFixIdentitiesTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class PatternFixIdentitiesTests
     {

--- a/src/DocoptNet.Tests/PatternFixRepeatingArgumentsTests.cs
+++ b/src/DocoptNet.Tests/PatternFixRepeatingArgumentsTests.cs
@@ -1,8 +1,8 @@
-using System.Collections;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections;
+    using NUnit.Framework;
+
     [TestFixture]
     public class PatternFixRepeatingArgumentsTests
     {

--- a/src/DocoptNet.Tests/PatternFlatTests.cs
+++ b/src/DocoptNet.Tests/PatternFlatTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class PatternFlatTests
     {

--- a/src/DocoptNet.Tests/RequiredMatchTests.cs
+++ b/src/DocoptNet.Tests/RequiredMatchTests.cs
@@ -1,8 +1,8 @@
-using NUnit.Framework;
-using static DocoptNet.Tests.PatternFactory;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
     [TestFixture]
     public class RequiredMatchTests
     {

--- a/src/DocoptNet.Tests/ShortOptionsErrorHandlingTests.cs
+++ b/src/DocoptNet.Tests/ShortOptionsErrorHandlingTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class ShortOptionsErrorHandlingTests
     {

--- a/src/DocoptNet.Tests/StringPartitionTests.cs
+++ b/src/DocoptNet.Tests/StringPartitionTests.cs
@@ -1,7 +1,7 @@
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using NUnit.Framework;
+
     [TestFixture]
     public class StringPartitionTests
     {

--- a/src/DocoptNet.Tests/SyntaxTests.cs
+++ b/src/DocoptNet.Tests/SyntaxTests.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class SyntaxTests
     {

--- a/src/DocoptNet.Tests/UsageTests.cs
+++ b/src/DocoptNet.Tests/UsageTests.cs
@@ -1,8 +1,8 @@
-using System.Linq;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Linq;
+    using NUnit.Framework;
+
     [TestFixture]
     public class UsageTests
     {

--- a/src/DocoptNet.Tests/ValueObjectTests.cs
+++ b/src/DocoptNet.Tests/ValueObjectTests.cs
@@ -1,9 +1,9 @@
-using System.Collections;
-using System.Collections.Generic;
-using NUnit.Framework;
-
 namespace DocoptNet.Tests
 {
+    using System.Collections;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+
     [TestFixture]
     public class ValueObjectTests
     {

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -1,8 +1,8 @@
-using System.Collections;
-using System.Collections.Generic;
-
 namespace DocoptNet
 {
+    using System.Collections;
+    using System.Collections.Generic;
+
     internal class Argument: LeafPattern
     {
         public Argument(string name, ValueObject value = null) : base(name, value)

--- a/src/DocoptNet/BranchPattern.cs
+++ b/src/DocoptNet/BranchPattern.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
     /// <summary>
     ///     Branch/inner node of a pattern tree.
     /// </summary>

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+
     internal class Command : Argument
     {
         public Command(string name, ValueObject value = null) : base(name, value ?? new ValueObject(false))

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Text;
+    using System.Text.RegularExpressions;
+
     public class Docopt
     {
         public event EventHandler<PrintExitEventArgs> PrintExit;

--- a/src/DocoptNet/Either.cs
+++ b/src/DocoptNet/Either.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     internal class Either : BranchPattern
     {
         public Either(params Pattern[] patterns) : base(patterns)

--- a/src/DocoptNet/LeafPattern.cs
+++ b/src/DocoptNet/LeafPattern.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
     /// <summary>
     /// Leaf/terminal node of a pattern tree.
     /// </summary>

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+    using System.Linq;
+
     internal class MatchResult
     {
         public bool Matched;

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace DocoptNet
 {
+    using System;
+
     public enum ValueType { Bool, List, String, }
 
     public class ArgumentNode : Node

--- a/src/DocoptNet/OneOrMore.cs
+++ b/src/DocoptNet/OneOrMore.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Diagnostics;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+    using System.Diagnostics;
+
     internal class OneOrMore : BranchPattern
     {
         public OneOrMore(params Pattern[] patterns)

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text.RegularExpressions;
+
     internal class Option : LeafPattern
     {
         public string ShortName { get; private set; }

--- a/src/DocoptNet/Optional.cs
+++ b/src/DocoptNet/Optional.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+
     internal class Optional : BranchPattern
     {
         public Optional(params Pattern[] patterns) : base(patterns)

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+
     internal abstract class Pattern
     {
         public virtual string Name

--- a/src/DocoptNet/Required.cs
+++ b/src/DocoptNet/Required.cs
@@ -1,7 +1,7 @@
-using System.Collections.Generic;
-
 namespace DocoptNet
 {
+    using System.Collections.Generic;
+
     internal class Required : BranchPattern
     {
         public Required(params Pattern[] patterns)

--- a/src/DocoptNet/Tokens.cs
+++ b/src/DocoptNet/Tokens.cs
@@ -1,11 +1,11 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+
     public class Tokens: IEnumerable<string>
     {
         private readonly Type _errorType;

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections;
-using System.Linq;
-
 namespace DocoptNet
 {
+    using System;
+    using System.Collections;
+    using System.Linq;
+
     public class ValueObject // TODO : IEquatable<ValueObject>
     {
         public object Value { get; private set; }

--- a/src/Examples/NavalFate/Program.cs
+++ b/src/Examples/NavalFate/Program.cs
@@ -1,8 +1,8 @@
-using System;
-using DocoptNet;
-
 namespace NavalFate
 {
+    using System;
+    using DocoptNet;
+
     internal class Program
     {
         private const string usage = @"Naval Fate.

--- a/src/T4DocoptNetHostApp/Program.cs
+++ b/src/T4DocoptNetHostApp/Program.cs
@@ -1,7 +1,7 @@
-using System;
-
 namespace T4DocoptNetHostApp
 {
+    using System;
+
     class Program
     {
         static void Main(string[] args)

--- a/src/Testee/Program.cs
+++ b/src/Testee/Program.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Text.Json;
-using DocoptNet;
-
 namespace Testee
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Text.Encodings.Web;
+    using System.Text.Json;
+    using DocoptNet;
+
     internal class Program
     {
         public static string Docopt(string doc, string[] cmdLine)


### PR DESCRIPTION
This PR move all `using` directives inside the namespace declarations. It aligns with the `csharp_using_directive_placement = inside_namespace` rule in `.editorconfig`.

Incidentally, this also enables concatenation of all sources into a single file for source-embedding scenarios such as the one requested in PR #8. For example, this could be done with a one-liner in the Windows Command Prompt shell:

    for %f in (*.cs) do @type %f >> %temp%\DocoptNet.cs

or in PowerShell:

```ps1
dir *.cs | % { Get-Content $_ | Out-File Temp:DocoptNet.cs -Append }
```
