### PR TITLE
Make public API predicated on "DOCOPTNET_PUBLIC"

### DIFF
--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -3,7 +3,7 @@ namespace DocoptNet
     using System.Collections;
     using System.Collections.Generic;
 
-    internal class Argument: LeafPattern
+    class Argument: LeafPattern
     {
         public Argument(string name, ValueObject value = null) : base(name, value)
         {

--- a/src/DocoptNet/BranchPattern.cs
+++ b/src/DocoptNet/BranchPattern.cs
@@ -7,7 +7,7 @@ namespace DocoptNet
     /// <summary>
     ///     Branch/inner node of a pattern tree.
     /// </summary>
-    internal class BranchPattern : Pattern
+    class BranchPattern : Pattern
     {
 
         public BranchPattern(params Pattern[] children)

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System.Collections.Generic;
 
-    internal class Command : Argument
+    class Command : Argument
     {
         public Command(string name, ValueObject value = null) : base(name, value ?? new ValueObject(false))
         {

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -7,7 +7,7 @@ namespace DocoptNet
     using System.Text;
     using System.Text.RegularExpressions;
 
-    public class Docopt
+    partial class Docopt
     {
         public event EventHandler<PrintExitEventArgs> PrintExit;
 
@@ -473,7 +473,7 @@ namespace DocoptNet
         }
     }
 
-    public class PrintExitEventArgs : EventArgs
+    partial class PrintExitEventArgs : EventArgs
     {
         public PrintExitEventArgs(string msg, int errorCode)
         {

--- a/src/DocoptNet/DocoptBaseException.cs
+++ b/src/DocoptNet/DocoptBaseException.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System;
 
-    public partial class DocoptBaseException : Exception
+    partial class DocoptBaseException : Exception
     {
         //
         // For guidelines regarding the creation of new exception types, see

--- a/src/DocoptNet/DocoptExitException.cs
+++ b/src/DocoptNet/DocoptExitException.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System;
 
-    public partial class DocoptExitException : DocoptBaseException
+    partial class DocoptExitException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see

--- a/src/DocoptNet/DocoptInputErrorException.cs
+++ b/src/DocoptNet/DocoptInputErrorException.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System;
 
-    public partial class DocoptInputErrorException : DocoptBaseException
+    partial class DocoptInputErrorException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see

--- a/src/DocoptNet/DocoptLanguageErrorException.cs
+++ b/src/DocoptNet/DocoptLanguageErrorException.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System;
 
-    public partial class DocoptLanguageErrorException : DocoptBaseException
+    partial class DocoptLanguageErrorException : DocoptBaseException
     {
         //
         // For guidelines regarding the creation of new exception types, see

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);DOCNETOPT_PUBLIC</DefineConstants>
     <!--
     TODO Remove the suppression of the following warnings after addressing them:
     - error NU5125: The 'licenseUrl' element will be deprecated.

--- a/src/DocoptNet/Either.cs
+++ b/src/DocoptNet/Either.cs
@@ -3,7 +3,7 @@ namespace DocoptNet
     using System.Collections.Generic;
     using System.Linq;
 
-    internal class Either : BranchPattern
+    class Either : BranchPattern
     {
         public Either(params Pattern[] patterns) : base(patterns)
         {

--- a/src/DocoptNet/Extensions.cs
+++ b/src/DocoptNet/Extensions.cs
@@ -1,6 +1,6 @@
 namespace DocoptNet
 {
-    public static class Extensions
+    static class Extensions
     {
         /// <summary>
         /// Split the <paramref name="input"/> at the first occurrence of <paramref name="separator"/>,

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -1,6 +1,6 @@
 namespace DocoptNet
 {
-    public static class GenerateCodeHelper
+    static class GenerateCodeHelper
     {
         public static string ConvertDashesToCamelCase(string s)
         {

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -3,7 +3,7 @@ namespace DocoptNet
     using System.Collections.Generic;
     using System.Linq;
 
-    internal class MatchResult
+    class MatchResult
     {
         public bool Matched;
         public IList<LeafPattern> Left;

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -2,24 +2,27 @@ namespace DocoptNet
 {
     using System;
 
-    public enum ValueType { Bool, List, String, }
+    #if DOCNETOPT_PUBLIC
+    public
+    #endif
+         enum ValueType { Bool, List, String, }
 
-    public class ArgumentNode : Node
+    partial class ArgumentNode : Node
     {
         public ArgumentNode(string name, ValueType valueType) : base(name, valueType) { }
     }
 
-    public class OptionNode : Node
+    partial class OptionNode : Node
     {
         public OptionNode(string name, ValueType valueType) : base(name, valueType) { }
     }
 
-    public class CommandNode : Node
+    partial class CommandNode : Node
     {
         public CommandNode(string name) : base(name, ValueType.Bool) { }
     }
 
-    public abstract class Node : IEquatable<Node>
+    abstract partial class Node : IEquatable<Node>
     {
         protected Node(string name, ValueType valueType)
         {

--- a/src/DocoptNet/OneOrMore.cs
+++ b/src/DocoptNet/OneOrMore.cs
@@ -3,7 +3,7 @@ namespace DocoptNet
     using System.Collections.Generic;
     using System.Diagnostics;
 
-    internal class OneOrMore : BranchPattern
+    class OneOrMore : BranchPattern
     {
         public OneOrMore(params Pattern[] patterns)
             : base(patterns)

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -4,7 +4,7 @@ namespace DocoptNet
     using System.Collections.Generic;
     using System.Text.RegularExpressions;
 
-    internal class Option : LeafPattern
+    class Option : LeafPattern
     {
         public string ShortName { get; private set; }
         public string LongName { get; private set; }

--- a/src/DocoptNet/Optional.cs
+++ b/src/DocoptNet/Optional.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System.Collections.Generic;
 
-    internal class Optional : BranchPattern
+    class Optional : BranchPattern
     {
         public Optional(params Pattern[] patterns) : base(patterns)
         {

--- a/src/DocoptNet/OptionsShortcut.cs
+++ b/src/DocoptNet/OptionsShortcut.cs
@@ -3,7 +3,7 @@ namespace DocoptNet
     /// <summary>
     ///     Marker/placeholder for [options] shortcut.
     /// </summary>
-    internal class OptionsShortcut : Optional
+    class OptionsShortcut : Optional
     {
         public OptionsShortcut() : base(new Pattern[0])
         {

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -6,7 +6,7 @@ namespace DocoptNet
     using System.Diagnostics;
     using System.Linq;
 
-    internal abstract class Pattern
+    abstract class Pattern
     {
         public virtual string Name
         {

--- a/src/DocoptNet/Public.cs
+++ b/src/DocoptNet/Public.cs
@@ -1,0 +1,19 @@
+#if DOCNETOPT_PUBLIC
+
+namespace DocoptNet
+{
+    public partial class Docopt { }
+    public partial class PrintExitEventArgs { }
+    public partial class DocoptBaseException { }
+    public partial class DocoptExitException { }
+    public partial class DocoptInputErrorException { }
+    public partial class DocoptLanguageErrorException { }
+    public partial class ArgumentNode { }
+    public partial class OptionNode { }
+    public partial class CommandNode { }
+    public partial class Node { }
+    public partial class Tokens { }
+    public partial class ValueObject { }
+}
+
+#endif

--- a/src/DocoptNet/Required.cs
+++ b/src/DocoptNet/Required.cs
@@ -2,7 +2,7 @@ namespace DocoptNet
 {
     using System.Collections.Generic;
 
-    internal class Required : BranchPattern
+    class Required : BranchPattern
     {
         public Required(params Pattern[] patterns)
             : base(patterns)

--- a/src/DocoptNet/Tokens.cs
+++ b/src/DocoptNet/Tokens.cs
@@ -6,7 +6,7 @@ namespace DocoptNet
     using System.Linq;
     using System.Text.RegularExpressions;
 
-    public class Tokens: IEnumerable<string>
+    partial class Tokens: IEnumerable<string>
     {
         private readonly Type _errorType;
         private readonly List<string> _tokens = new List<string>();

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -4,7 +4,7 @@ namespace DocoptNet
     using System.Collections;
     using System.Linq;
 
-    public class ValueObject // TODO : IEquatable<ValueObject>
+    partial class ValueObject // TODO : IEquatable<ValueObject>
     {
         public object Value { get; private set; }
 


### PR DESCRIPTION
While PR #76 had the nice side-effect enabling source-embedding, it also meant that the public API would leak into the parent project. This PR enables _private_ embedding scenarios easily without any additional effort. It does so by marking all type definitions in the **DocoptNet** project as being `partial` and moves the `public` modifier for those types to `Public.cs` (the only exception is the `ValueType` enumeration since `partial` is not allowed on `enum`). What's more, `Public.cs` is entirely predicated on the conditional compilation symbol `DOCOPTNET_PUBLIC` being defined. The overall effect of this is that if anyone embeds the sources then they'll get private embedding by default; they won't unknowingly leak anything into their project's public API (unless of course `DOCOPTNET_PUBLIC` is defined in the host project but that would have to be an intentional action).

The source generator in PR #77 will benefit from this as I currently embed **DocoptNet** sources into the source generator project:

```xml
<ItemGroup>
  <Compile Include="..\DocoptNet\*.cs" Link="DocoptNet\%(Filename)" />
</ItemGroup>
```

In this PR, I removed `Extensions` from being public since I think `StringPartition` (before PR #69) should have been public in the first place. I also removed the `internal` modifier from all types for sake of consistency since that's the default in C# anyhow.

---
PS Like PR #76, this PR sort-of adds to #8.
