### PR TITLE
Remove APIs removed from public access

### DIFF
--- a/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Shipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Shipped.txt
@@ -29,8 +29,6 @@ DocoptNet.DocoptLanguageErrorException
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException() -> void
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException(string message) -> void
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException(string message, System.Exception inner) -> void
-DocoptNet.Extensions
-DocoptNet.GenerateCodeHelper
 DocoptNet.Node
 DocoptNet.Node.Equals(DocoptNet.Node other) -> bool
 DocoptNet.Node.Name.get -> string
@@ -74,6 +72,4 @@ override DocoptNet.Tokens.ToString() -> string
 override DocoptNet.ValueObject.Equals(object obj) -> bool
 override DocoptNet.ValueObject.GetHashCode() -> int
 override DocoptNet.ValueObject.ToString() -> string
-static DocoptNet.Extensions.Partition(this string input, string separator) -> (string, string, string)
-static DocoptNet.GenerateCodeHelper.ConvertDashesToCamelCase(string s) -> string
 static DocoptNet.Tokens.FromPattern(string pattern) -> DocoptNet.Tokens

--- a/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -33,8 +33,6 @@ DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException() -> void
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException(string message) -> void
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException(string message, System.Exception inner) -> void
 DocoptNet.DocoptLanguageErrorException.DocoptLanguageErrorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-DocoptNet.Extensions
-DocoptNet.GenerateCodeHelper
 DocoptNet.Node
 DocoptNet.Node.Equals(DocoptNet.Node other) -> bool
 DocoptNet.Node.Name.get -> string
@@ -78,6 +76,4 @@ override DocoptNet.Tokens.ToString() -> string
 override DocoptNet.ValueObject.Equals(object obj) -> bool
 override DocoptNet.ValueObject.GetHashCode() -> int
 override DocoptNet.ValueObject.ToString() -> string
-static DocoptNet.Extensions.Partition(this string input, string separator) -> (string, string, string)
-static DocoptNet.GenerateCodeHelper.ConvertDashesToCamelCase(string s) -> string
 static DocoptNet.Tokens.FromPattern(string pattern) -> DocoptNet.Tokens


### PR DESCRIPTION
This PR fixes builds now breaking (3b70613f1bffa863a34dc213ef81178ce99e6feb that's merge of PR #79 and 97a59cf29f3c63b617b0ff6f586f13e9fb063349 that's merge of PR #80) due to changes in the public API and monitoring thereof added in PR #78:

    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard2.0\PublicAPI.Shipped.txt(36,1): error RS0017: Symbol 'DocoptNet.Extensions' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard2.0\PublicAPI.Shipped.txt(37,1): error RS0017: Symbol 'DocoptNet.GenerateCodeHelper' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard2.0\PublicAPI.Shipped.txt(81,1): error RS0017: Symbol 'static DocoptNet.Extensions.Partition(this string input, string separator) -> (string, string, string)' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard2.0\PublicAPI.Shipped.txt(82,1): error RS0017: Symbol 'static DocoptNet.GenerateCodeHelper.ConvertDashesToCamelCase(string s) -> string' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard1.5\PublicAPI.Shipped.txt(32,1): error RS0017: Symbol 'DocoptNet.Extensions' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard1.5\PublicAPI.Shipped.txt(33,1): error RS0017: Symbol 'DocoptNet.GenerateCodeHelper' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard1.5\PublicAPI.Shipped.txt(77,1): error RS0017: Symbol 'static DocoptNet.Extensions.Partition(this string input, string separator) -> (string, string, string)' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]
    C:\projects\docopt-net\src\DocoptNet\PublicAPI\netstandard1.5\PublicAPI.Shipped.txt(78,1): error RS0017: Symbol 'static DocoptNet.GenerateCodeHelper.ConvertDashesToCamelCase(string s) -> string' is part of the declared API, but is either not public or could not be found [C:\projects\docopt-net\src\DocoptNet\DocoptNet.csproj]

---
PS I wonder how this could have been avoided. Normally the merge of PR #78 should have re-triggered a build of the other two PRs against `master` and failed prior to their merging. Either a configuration is missing on GitHub or AppVeyor end.

