### PR TITLE
Consolidate duplication of "collected + [match]" in leaf pattern matching

### DIFF
--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -91,16 +91,12 @@ namespace DocoptNet
                         if (sameName.Count == 0)
                         {
                             match.Value = increment;
-                            var res = new List<LeafPattern>(coll) {match};
-                            return new MatchResult(true, left_, res);
+                            return new MatchResult(true, left_, new List<LeafPattern>(coll) { match });
                         }
                         sameName[0].Value.Add(increment);
                         return new MatchResult(true, left_, coll);
                     }
-                    var resColl = new List<LeafPattern>();
-                    resColl.AddRange(coll);
-                    resColl.Add(match);
-                    return new MatchResult(true, left_, resColl);
+                    return new MatchResult(true, left_, new List<LeafPattern>(coll) { match });
                 }
                 default: throw new ArgumentException(nameof(pattern));
             }


### PR DESCRIPTION
This is a small PR to express `collected + [match]` as `new List<LeafPattern>(coll) { match }` in two code paths of leaf pattern matching. It also brings it strikingly close to the [same part in the Python reference implementation](https://github.com/docopt/docopt/blob/20b9c4ffec71d17cee9fd963238c8ec240905b65/docopt.py#L119-L130): 😉 

```py
if type(self.value) in (int, list):
    if type(self.value) is int:
        increment = 1
    else:
        increment = ([match.value] if type(match.value) is str
                        else match.value)
    if not same_name:
        match.value = incrementgit 
        return True, left_, collected + [match]
    same_name[0].value += increment
    return True, left_, collected
return True, left_, collected + [match]
```
