### PR TITLE
Use queue for "Tokens" for efficient head removals

### DIFF
--- a/src/DocoptNet/Tokens.cs
+++ b/src/DocoptNet/Tokens.cs
@@ -9,18 +9,18 @@ namespace DocoptNet
     partial class Tokens: IEnumerable<string>
     {
         private readonly Type _errorType;
-        private readonly List<string> _tokens = new List<string>();
+        private readonly Queue<string> _tokens;
 
         public Tokens(IEnumerable<string> source, Type errorType)
         {
             _errorType = errorType ?? typeof(DocoptInputErrorException);
-            _tokens.AddRange(source);
+            _tokens = new Queue<string>(source);
         }
 
         public Tokens(string source, Type errorType)
         {
             _errorType = errorType ?? typeof(DocoptInputErrorException);
-            _tokens.AddRange(source.Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
+            _tokens = new Queue<string>(source.Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
         }
 
         public Type ErrorType
@@ -52,18 +52,12 @@ namespace DocoptNet
 
         public string Move()
         {
-            string s = null;
-            if (_tokens.Count > 0)
-            {
-                s = _tokens[0];
-                _tokens.RemoveAt(0);
-            }
-            return s;
+            return _tokens.Count > 0 ? _tokens.Dequeue() : null;
         }
 
         public string Current()
         {
-            return (_tokens.Count > 0) ? _tokens[0] : null;
+            return _tokens.Count > 0 ? _tokens.Peek() : null;
         }
 
         public Exception CreateException(string message)


### PR DESCRIPTION
This PR is a minor improvement that uses a data structure, a queue, that's friendlier to removing the head element. [`List<>` causes big moves on each removal](https://github.com/dotnet/runtime/blob/82ca681cbac89d813a3ce397e0c665e6c051ed67/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs#L917-L933) where as its [super cheap with a `Queue<>`](https://github.com/dotnet/runtime/blob/82ca681cbac89d813a3ce397e0c665e6c051ed67/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs#L213-L232).