### PR TITLE
Optimise either pattern match for allocations

### DIFF
--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -28,16 +28,16 @@ namespace DocoptNet
                 }
                 case Either either:
                 {
-                    var outcomes =
-                        either.Children.Select(pattern => Match(pattern, left, coll))
-                              .Where(outcome => outcome.Matched)
-                              .ToList();
-                    if (outcomes.Count != 0)
+                    MatchResult match = null;
+                    foreach (var child in either.Children)
                     {
-                        var minCount = outcomes.Min(x => x.Left.Count);
-                        return outcomes.First(x => x.Left.Count == minCount);
+                        if (child.Match(left, coll) is (true, var l, var c)
+                            && (match is null || match is { Left: { Count: var mlc } } && l.Count < mlc))
+                        {
+                            match = new MatchResult(true, l, c);
+                        }
                     }
-                    return new MatchResult(false, left, coll);
+                    return match ?? new MatchResult(false, left, coll);
                 }
                 case Optional optional:
                 {


### PR DESCRIPTION
The PR optimises the implementation for the either branch pattern to make fewer allocations and list scans. It's now a straightforward `foreach` loop that looks for the match that _collects_ most leaf patterns.