### PR TITLE
Make "PatternMatcher" null-safe

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -52,7 +52,7 @@ namespace DocoptNet
                     optionsShortcut.Children = docOptions.Distinct().Except(patternOptions).ToList();
                 }
                 Extras(help, version, arguments, doc);
-                if (pattern.Fix().Match(arguments, null) is (true, { Count: 0 }, _) res)
+                if (pattern.Fix().Match(arguments) is (true, { Count: 0 }, _) res)
                 {
                     var dict = new Dictionary<string, ValueObject>();
                     foreach (var p in pattern.Flat().OfType<LeafPattern>())

--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -102,47 +102,48 @@ namespace DocoptNet
                         return new MatchResult(true, left_, collected);
                     }
                     return new MatchResult(true, left_, new List<LeafPattern>(collected) { match });
-                }
-                default: throw new ArgumentException(nameof(pattern));
-            }
 
-            static (int, LeafPattern?) SingleMatch(LeafPattern pattern, IList<LeafPattern> left)
-            {
-                switch (pattern)
-                {
-                    case Command command:
+                    static (int, LeafPattern?) SingleMatch(LeafPattern pattern, IList<LeafPattern> left)
                     {
-                        for (var i = 0; i < left.Count; i++)
+                        switch (pattern)
                         {
-                            if (left[i] is Argument { Value: { } value })
+                            case Command command:
                             {
-                                if (value.ToString() == command.Name)
-                                    return (i, new Command(command.Name, new ValueObject(true)));
-                                break;
+                                for (var i = 0; i < left.Count; i++)
+                                {
+                                    if (left[i] is Argument { Value: { } value })
+                                    {
+                                        if (value.ToString() == command.Name)
+                                            return (i, new Command(command.Name, new ValueObject(true)));
+                                        break;
+                                    }
+                                }
+                                return default;
                             }
+                            case Argument argument:
+                            {
+                                for (var i = 0; i < left.Count; i++)
+                                {
+                                    if (left[i] is Argument { Value: var value })
+                                        return (i, new Argument(argument.Name, value));
+                                }
+                                return default;
+                            }
+                            case Option option:
+                            {
+                                for (var i = 0; i < left.Count; i++)
+                                {
+                                    if (left[i].Name == option.Name)
+                                        return (i, left[i]);
+                                }
+                                return default;
+                            }
+                            default: throw new ArgumentException(nameof(pattern));
                         }
-                        return default;
                     }
-                    case Argument argument:
-                    {
-                        for (var i = 0; i < left.Count; i++)
-                        {
-                            if (left[i] is Argument { Value: var value })
-                                return (i, new Argument(argument.Name, value));
-                        }
-                        return default;
-                    }
-                    case Option option:
-                    {
-                        for (var i = 0; i < left.Count; i++)
-                        {
-                            if (left[i].Name == option.Name)
-                                return (i, left[i]);
-                        }
-                        return default;
-                    }
-                    default: throw new ArgumentException(nameof(pattern));
                 }
+                default:
+                    throw new ArgumentException(nameof(pattern));
             }
         }
     }

--- a/tests/DocoptNet.Tests/Extensions.cs
+++ b/tests/DocoptNet.Tests/Extensions.cs
@@ -4,7 +4,7 @@ namespace DocoptNet.Tests
     {
         public static MatchResult Match(this Pattern pattern, params LeafPattern[] left)
         {
-            return pattern.Match(left, null);
+            return PatternMatcher.Match(pattern, left);
         }
     }
 }


### PR DESCRIPTION
This PR [enables the nullable context](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references#nullable-contexts) for `PatternMatcher` updates some parts of the code to be safer and simpler with respect to nullability.

A big change is refactoring of `SingleMatch` into `MatchLeaf`, which has the benefit of having a single `switch` statement that covers all cases (instead of two previously: branches and leaves) and is easier to follow.

All tests still pass.

---
Please consult [the individual commits of this PR](https://github.com/docopt/docopt.net/pull/86/commits) to follow the changes in logical steps if the overall delta with the target branch is harder to read/review.