### PR TITLE
Replace "string.Format" uses with interpolated strings

### DIFF
--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -35,7 +35,7 @@ namespace DocoptNet
 
             if (Value != null && Value.IsList)
             {
-                return string.Format("public ArrayList {0} {{ get {{ return _args[\"{1}\"].AsList; }} }}", s, Name);
+                return $"public ArrayList {s} {{ get {{ return _args[\"{Name}\"].AsList; }} }}";
             }
             return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? null : _args[\"{1}\"].ToString(); }} }}", s, Name);
         }

--- a/src/DocoptNet/Array.cs
+++ b/src/DocoptNet/Array.cs
@@ -1,0 +1,7 @@
+namespace DocoptNet
+{
+    static class Array<T>
+    {
+        public static readonly T[] Empty = new T[0];
+    }
+}

--- a/src/DocoptNet/BranchPatterns.cs
+++ b/src/DocoptNet/BranchPatterns.cs
@@ -34,7 +34,7 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("{0}({1})", GetType().Name, string.Join(", ", Children.Select(c => c == null ? "None" : c.ToString())));
+            return $"{GetType().Name}({string.Join(", ", Children.Select(c => c == null ? "None" : c.ToString()))})";
         }
     }
 

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -12,7 +12,7 @@ namespace DocoptNet
         {
             var s = Name.ToLowerInvariant();
             s = "Cmd" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
-            return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
+            return $"public bool {s} {{ get {{ return _args[\"{Name}\"].IsTrue; }} }}";
         }
 
     }

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -348,8 +348,7 @@ namespace DocoptNet
                 Option option = null;
                 if (similar.Count > 1)
                 {
-                    throw tokens.CreateException(string.Format("{0} is specified ambiguously {1} times", shortName,
-                        similar.Count));
+                    throw tokens.CreateException($"{shortName} is specified ambiguously {similar.Count} times");
                 }
                 if (similar.Count < 1)
                 {
@@ -408,8 +407,7 @@ namespace DocoptNet
             if (similar.Count > 1)
             {
                 // Might be simply specified ambiguously 2+ times?
-                throw tokens.CreateException(string.Format("{0} is not a unique prefix: {1}?", longName,
-                    string.Join(", ", similar.Select(o => o.LongName))));
+                throw tokens.CreateException($"{longName} is not a unique prefix: {string.Join(", ", similar.Select(o => o.LongName))}?");
             }
             Option option = null;
             if (similar.Count < 1)

--- a/src/DocoptNet/LeafPattern.cs
+++ b/src/DocoptNet/LeafPattern.cs
@@ -40,7 +40,7 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("{0}({1}, {2})", GetType().Name, Name, Value);
+            return $"{GetType().Name}({Name}, {Value})";
         }
     }
 }

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -42,11 +42,9 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("matched={0} left=[{1}], collected=[{2}]",
-                Matched,
-                Left == null ? "" : string.Join(", ", Left.Select(p => p.ToString())),
-                Collected == null ? "" : string.Join(", ", Collected.Select(p => p.ToString()))
-            );
+            var left = string.Join(", ", Left ?? Array<LeafPattern>.Empty);
+            var collected = string.Join(", ", Collected ?? Array<LeafPattern>.Empty);
+            return $"matched={Matched} left=[{left}], collected=[{collected}]";
         }
 
         public void Deconstruct(out bool matched, out IList<LeafPattern> left, out IEnumerable<LeafPattern> collected)

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -37,7 +37,7 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("{0} {1} {2}", GetType().Name, Name, ValueType);
+            return $"{GetType().Name} {Name} {ValueType}";
         }
 
         public override int GetHashCode()

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -41,15 +41,15 @@ namespace DocoptNet
 
             if (ArgCount == 0)
             {
-                return string.Format("public bool {0} {{ get {{ return _args[\"{1}\"].IsTrue; }} }}", s, Name);
+                return $"public bool {s} {{ get {{ return _args[\"{Name}\"].IsTrue; }} }}";
             }
-            var defaultValue = Value == null ? "null" : string.Format("\"{0}\"", Value);
+            var defaultValue = Value == null ? "null" : $"\"{Value}\"";
             return string.Format("public string {0} {{ get {{ return null == _args[\"{1}\"] ? {2} : _args[\"{1}\"].ToString(); }} }}", s, Name, defaultValue);
         }
 
         public override string ToString()
         {
-            return string.Format("Option({0},{1},{2},{3})", ShortName, LongName, ArgCount, Value);
+            return $"Option({ShortName},{LongName},{ArgCount},{Value})";
         }
 
         private const string DESC_SEPARATOR = "  ";

--- a/src/DocoptNet/Tokens.cs
+++ b/src/DocoptNet/Tokens.cs
@@ -67,7 +67,7 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            return string.Format("current={0},count={1}", Current(), _tokens.Count);
+            return $"current={Current()},count={_tokens.Count}";
         }
     }
 }

--- a/src/DocoptNet/ValueObject.cs
+++ b/src/DocoptNet/ValueObject.cs
@@ -93,7 +93,7 @@ namespace DocoptNet
             if (IsList)
             {
                 var l = (from object v in AsList select v.ToString()).ToList();
-                return string.Format("[{0}]", string.Join(", ", l));
+                return $"[{string.Join(", ", l)}]";
             }
             return (Value ?? "").ToString();
         }


### PR DESCRIPTION
A simple PR that replaces uses of `string.Format` with interpolated strings that are often easier to read, get right and maintain when compared to indexed replacements, assuming localization of messages isn't planned in the near or far future.
