### PR TITLE
Make immutable lists in pattern matching obvious

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -2,7 +2,6 @@ namespace DocoptNet
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
@@ -44,7 +43,7 @@ namespace DocoptNet
                 var exitUsage = usageSections[0];
                 var options = ParseDefaults(doc);
                 var pattern = ParsePattern(FormalUsage(exitUsage), options);
-                var arguments = new ReadOnlyCollection<LeafPattern>(ParseArgv(tokens, options, optionsFirst));
+                var arguments = ParseArgv(tokens, options, optionsFirst).AsReadOnly();
                 var patternOptions = pattern.Flat<Option>().Distinct().ToList();
                 // [default] syntax for argument is disabled
                 foreach (OptionsShortcut optionsShortcut in pattern.Flat(typeof (OptionsShortcut)))

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -2,6 +2,7 @@ namespace DocoptNet
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
@@ -43,7 +44,7 @@ namespace DocoptNet
                 var exitUsage = usageSections[0];
                 var options = ParseDefaults(doc);
                 var pattern = ParsePattern(FormalUsage(exitUsage), options);
-                var arguments = ParseArgv(tokens, options, optionsFirst);
+                var arguments = new ReadOnlyCollection<LeafPattern>(ParseArgv(tokens, options, optionsFirst));
                 var patternOptions = pattern.Flat<Option>().Distinct().ToList();
                 // [default] syntax for argument is disabled
                 foreach (OptionsShortcut optionsShortcut in pattern.Flat(typeof (OptionsShortcut)))
@@ -132,7 +133,7 @@ namespace DocoptNet
             return pattern.Fix().Flat();
         }
 
-        private void Extras(bool help, object version, ICollection<LeafPattern> options, string doc)
+        private void Extras(bool help, object version, IReadOnlyList<LeafPattern> options, string doc)
         {
             if (help && options.Any(o => (o.Name == "-h" || o.Name == "--help") && !o.Value.IsNullOrEmpty))
             {

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -132,7 +132,7 @@ namespace DocoptNet
             return pattern.Fix().Flat();
         }
 
-        private void Extras(bool help, object version, IReadOnlyList<LeafPattern> options, string doc)
+        private void Extras(bool help, object version, ReadOnlyList<LeafPattern> options, string doc)
         {
             if (help && options.Any(o => (o.Name == "-h" || o.Name == "--help") && !o.Value.IsNullOrEmpty))
             {

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -5,13 +5,13 @@ namespace DocoptNet
 
     class MatchResult
     {
-        public bool Matched;
-        public IList<LeafPattern> Left;
-        public IEnumerable<LeafPattern> Collected;
+        public readonly bool Matched;
+        public readonly IReadOnlyList<LeafPattern> Left;
+        public readonly IReadOnlyList<LeafPattern> Collected;
 
         public MatchResult() { }
 
-        public MatchResult(bool matched, IList<LeafPattern> left, IEnumerable<LeafPattern> collected)
+        public MatchResult(bool matched, IReadOnlyList<LeafPattern> left, IReadOnlyList<LeafPattern> collected)
         {
             Matched = matched;
             Left = left;
@@ -47,7 +47,7 @@ namespace DocoptNet
             return $"matched={Matched} left=[{left}], collected=[{collected}]";
         }
 
-        public void Deconstruct(out bool matched, out IList<LeafPattern> left, out IEnumerable<LeafPattern> collected)
+        public void Deconstruct(out bool matched, out IReadOnlyList<LeafPattern> left, out IReadOnlyList<LeafPattern> collected)
         {
             (matched, left, collected) = (Matched, Left, Collected);
         }

--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -1,17 +1,14 @@
 namespace DocoptNet
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     class MatchResult
     {
         public readonly bool Matched;
-        public readonly IReadOnlyList<LeafPattern> Left;
-        public readonly IReadOnlyList<LeafPattern> Collected;
+        public readonly ReadOnlyList<LeafPattern> Left;
+        public readonly ReadOnlyList<LeafPattern> Collected;
 
         public MatchResult() { }
 
-        public MatchResult(bool matched, IReadOnlyList<LeafPattern> left, IReadOnlyList<LeafPattern> collected)
+        public MatchResult(bool matched, ReadOnlyList<LeafPattern> left, ReadOnlyList<LeafPattern> collected)
         {
             Matched = matched;
             Left = left;
@@ -42,12 +39,12 @@ namespace DocoptNet
 
         public override string ToString()
         {
-            var left = string.Join(", ", Left ?? Array<LeafPattern>.Empty);
-            var collected = string.Join(", ", Collected ?? Array<LeafPattern>.Empty);
+            var left = string.Join(", ", Left);
+            var collected = string.Join(", ", Collected);
             return $"matched={Matched} left=[{left}], collected=[{collected}]";
         }
 
-        public void Deconstruct(out bool matched, out IReadOnlyList<LeafPattern> left, out IReadOnlyList<LeafPattern> collected)
+        public void Deconstruct(out bool matched, out ReadOnlyList<LeafPattern> left, out ReadOnlyList<LeafPattern> collected)
         {
             (matched, left, collected) = (Matched, Left, Collected);
         }

--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -9,12 +9,14 @@ namespace DocoptNet
 
     static class PatternMatcher
     {
-        public static MatchResult Match(this Pattern pattern, IReadOnlyList<LeafPattern> left)
+        public static MatchResult Match(this Pattern pattern, ReadOnlyList<LeafPattern> left)
         {
-            return pattern.Match(left, new List<LeafPattern>());
+            return pattern.Match(left, new ReadOnlyList<LeafPattern>());
         }
 
-        static MatchResult Match(this Pattern pattern, IReadOnlyList<LeafPattern> left, IReadOnlyList<LeafPattern> collected)
+        static MatchResult Match(this Pattern pattern,
+                                 ReadOnlyList<LeafPattern> left,
+                                 ReadOnlyList<LeafPattern> collected)
         {
             switch (pattern)
             {
@@ -57,7 +59,7 @@ namespace DocoptNet
                     Debug.Assert(oneOrMore.Children.Count == 1);
                     var l = left;
                     var c = collected;
-                    IReadOnlyList<LeafPattern>? l_ = null;
+                    ReadOnlyList<LeafPattern>? l_ = null;
                     var matched = true;
                     var times = 0;
                     while (matched)
@@ -112,9 +114,7 @@ namespace DocoptNet
 
             MatchResult MatchLeaf(LeafPattern leaf, int index, LeafPattern match)
             {
-                var left_ = new List<LeafPattern>();
-                left_.AddRange(left.Take(index));
-                left_.AddRange(left.Skip(index + 1));
+                var left_ = left.RemoveAt(index);
                 var sameName = collected.Where(a => a.Name == leaf.Name).ToList();
                 if (leaf.Value is { IsList: true } or { IsOfTypeInt: true })
                 {
@@ -126,12 +126,12 @@ namespace DocoptNet
                     if (sameName.Count == 0)
                     {
                         match.Value = increment;
-                        return new MatchResult(true, left_, new List<LeafPattern>(collected) { match });
+                        return new MatchResult(true, left_, collected.Append(match));
                     }
                     sameName[0].Value.Add(increment);
                     return new MatchResult(true, left_, collected);
                 }
-                return new MatchResult(true, left_, new List<LeafPattern>(collected) { match });
+                return new MatchResult(true, left_, collected.Append(match));
             }
         }
     }

--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -9,12 +9,12 @@ namespace DocoptNet
 
     static class PatternMatcher
     {
-        public static MatchResult Match(this Pattern pattern, IList<LeafPattern> left)
+        public static MatchResult Match(this Pattern pattern, IReadOnlyList<LeafPattern> left)
         {
             return pattern.Match(left, new List<LeafPattern>());
         }
 
-        static MatchResult Match(this Pattern pattern, IList<LeafPattern> left, IEnumerable<LeafPattern> collected)
+        static MatchResult Match(this Pattern pattern, IReadOnlyList<LeafPattern> left, IReadOnlyList<LeafPattern> collected)
         {
             switch (pattern)
             {
@@ -57,7 +57,7 @@ namespace DocoptNet
                     Debug.Assert(oneOrMore.Children.Count == 1);
                     var l = left;
                     var c = collected;
-                    IList<LeafPattern>? l_ = null;
+                    IReadOnlyList<LeafPattern>? l_ = null;
                     var matched = true;
                     var times = 0;
                     while (matched)

--- a/src/DocoptNet/ReadOnlyList.cs
+++ b/src/DocoptNet/ReadOnlyList.cs
@@ -1,0 +1,61 @@
+namespace DocoptNet
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    static class ReadOnlyList
+    {
+        public static ReadOnlyList<T> AsReadOnly<T>(this IList<T> list) => new(list);
+    }
+
+    /// <summary>
+    /// A read-only wrapper for <seealso cref="IList{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// It is the responsibility of the initializer to guarantee that the wrapped and possibly
+    /// read-write <seealso cref="IList{T}"/> is not changed.
+    /// </remarks>
+
+    readonly struct ReadOnlyList<T> : IReadOnlyList<T>
+    {
+        static readonly T[] EmptyArray = new T[0];
+
+        readonly IList<T> _list;
+
+        public ReadOnlyList(IList<T> list) => _list = list;
+        IList<T> List => _list ?? EmptyArray;
+        public int Count => List.Count;
+        public T this[int index] => List[index];
+        public IEnumerator<T> GetEnumerator() => List.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public ReadOnlyList<T> Append(T item)
+        {
+            var array = new T[Count + 1];
+            CopyTo(array, 0, Count);
+            array[Count] = item;
+            return array.AsReadOnly();
+        }
+
+        public ReadOnlyList<T> RemoveAt(int index)
+        {
+            var array = new T[Count - 1];
+            CopyTo(array, 0, index);
+            CopyTo(array, index, index + 1, Count - index - 1);
+            return array.AsReadOnly();
+        }
+
+        void CopyTo(T[] array, int index, int count) =>
+            CopyTo(array, 0, index, count);
+
+        void CopyTo(T[] array, int targetIndex, int sourceIndex, int count)
+        {
+            var list = List;
+            while (count > 0)
+            {
+                array[targetIndex++] = list[sourceIndex++];
+                count--;
+            }
+        }
+    }
+}

--- a/src/DocoptNet/ReadOnlyList.cs
+++ b/src/DocoptNet/ReadOnlyList.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace DocoptNet
 {
     using System.Collections;

--- a/tests/DocoptNet.Tests/Extensions.cs
+++ b/tests/DocoptNet.Tests/Extensions.cs
@@ -4,7 +4,7 @@ namespace DocoptNet.Tests
     {
         public static MatchResult Match(this Pattern pattern, params LeafPattern[] left)
         {
-            return PatternMatcher.Match(pattern, left);
+            return PatternMatcher.Match(pattern, left.AsReadOnly());
         }
     }
 }

--- a/tests/DocoptNet.Tests/PatternFactory.cs
+++ b/tests/DocoptNet.Tests/PatternFactory.cs
@@ -2,9 +2,7 @@ namespace DocoptNet.Tests
 {
     static class PatternFactory
     {
-        static readonly LeafPattern[] ZeroLeaves = new LeafPattern[0];
-
-        public static LeafPattern[] Leaves() => ZeroLeaves;
-        public static LeafPattern[] Leaves(params LeafPattern[] leaves) => leaves;
+        public static ReadOnlyList<LeafPattern> Leaves() => new ReadOnlyList<LeafPattern>();
+        public static ReadOnlyList<LeafPattern> Leaves(params LeafPattern[] leaves) => leaves.AsReadOnly();
     }
 }


### PR DESCRIPTION
This PR introduces `ReadOnlyList<>` as a very thin veil (`struct`) around an array and uses it in signatures to make immutable lists/collections in pattern matching obvious. The lists were never modified previously (new copies were generated on modification), but this wasn't clear or evident. There's no change to what was there before, so this PR just makes the constraints/design more formal through a type like `ReadOnlyList<>`.