### PR TITLE
Default either pattern match result (avoids null)

### DIFF
--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -35,16 +35,16 @@ namespace DocoptNet
                 }
                 case Either either:
                 {
-                    MatchResult? match = null;
+                    var match = new MatchResult(false, left, collected);
                     foreach (var child in either.Children)
                     {
                         if (child.Match(left, collected) is (true, var l, var c)
-                            && (match is null || l.Count < match.Left.Count))
+                            && (!match.Matched || l.Count < match.Left.Count))
                         {
                             match = new MatchResult(true, l, c);
                         }
                     }
-                    return match ?? new MatchResult(false, left, collected);
+                    return match;
                 }
                 case Optional optional:
                 {


### PR DESCRIPTION
This PR initializes a default in the either pattern matching branch so as to avoid having to deal with null references at all.