### PR TITLE
Convert `MatchResult` into a read-only value type

### DIFF
--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -1,6 +1,6 @@
 namespace DocoptNet
 {
-    class MatchResult
+    readonly struct MatchResult
     {
         public readonly bool Matched;
         public readonly ReadOnlyList<LeafPattern> Left;


### PR DESCRIPTION
This saves on allocations for a frequently used, small & simple type.

The only ramification of this change is that `default(MatchResult)` not means a mismatch with empty leaves as opposed to `null`.
