### PR TITLE
Add unit tests for `MatchResult`

### DIFF
--- a/tests/DocoptNet.Tests/MatchResultTests.cs
+++ b/tests/DocoptNet.Tests/MatchResultTests.cs
@@ -1,0 +1,42 @@
+namespace DocoptNet.Tests
+{
+    using NUnit.Framework;
+    using static DocoptNet.Tests.PatternFactory;
+
+    [TestFixture]
+    public class MatchResultTests
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void Initialization(bool matched)
+        {
+            var left = Leaves(new Option("-a"));
+            var collected = Leaves(new Option("-b"));
+            var match = new MatchResult(matched, left, collected);
+
+            Assert.That(match.Matched, Is.EqualTo(matched));
+            Assert.That(match.Left, Is.EqualTo(left));
+            Assert.That(match.Collected, Is.EqualTo(collected));
+        }
+
+        [Test]
+        public void Default_Is_Mismatch_Having_Empty_Leaves()
+        {
+            var match = default(MatchResult); // == new MatchResult()
+            Assert.That(match.Matched, Is.False);
+            Assert.That(match.Left, Is.Empty);
+            Assert.That(match.Collected, Is.Empty);
+        }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var match = new MatchResult(true, Leaves(new Option("-a")), Leaves(new Option("-b")));
+            var (matched, left, collected) = match;
+
+            Assert.That(matched, Is.EqualTo(match.Matched));
+            Assert.That(left, Is.EqualTo(match.Left));
+            Assert.That(collected, Is.EqualTo(match.Collected));
+        }
+    }
+}


### PR DESCRIPTION
Still missing are tests for equality, but many (if not all) equality implementations need revision since they cause a lot of string allocations. The tests could then be added at the time the implementations are revised.