### PR TITLE
Add operators making `MatchResult` Boolean-ish

### DIFF
--- a/src/DocoptNet/MatchResult.cs
+++ b/src/DocoptNet/MatchResult.cs
@@ -46,5 +46,9 @@ namespace DocoptNet
         {
             (matched, left, collected) = (Matched, Left, Collected);
         }
+
+        public static bool operator true(MatchResult result) => result.Matched;
+        public static bool operator false(MatchResult result) => !result;
+        public static bool operator !(MatchResult result) => result ? false : true;
     }
 }

--- a/src/DocoptNet/PatternMatcher.cs
+++ b/src/DocoptNet/PatternMatcher.cs
@@ -38,7 +38,7 @@ namespace DocoptNet
                     foreach (var child in either.Children)
                     {
                         if (child.Match(left, collected) is (true, var l, var c)
-                            && (!match.Matched || l.Count < match.Left.Count))
+                            && (!match || l.Count < match.Left.Count))
                         {
                             match = new MatchResult(true, l, c);
                         }

--- a/tests/DocoptNet.Tests/MatchResultTests.cs
+++ b/tests/DocoptNet.Tests/MatchResultTests.cs
@@ -38,5 +38,47 @@ namespace DocoptNet.Tests
             Assert.That(left, Is.EqualTo(match.Left));
             Assert.That(collected, Is.EqualTo(match.Collected));
         }
+
+        [Test]
+        public void Definitely_True_When_Matched()
+        {
+            var match = new MatchResult(true, Leaves(), Leaves());
+
+            if (match)
+                Assert.Pass();
+            else
+                Assert.Fail();
+        }
+
+        [Test]
+        public void Not_Definitely_True_When_Not_Matched()
+        {
+            var match = new MatchResult(false, Leaves(), Leaves());
+
+            if (match)
+                Assert.Fail();
+            else
+                Assert.Pass();
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Definitely_False(bool matched)
+        {
+            var match = new MatchResult(matched, Leaves(), Leaves());
+            // Direct invocation of some operators is forbidden:
+            //     MatchResult.op_False(match);
+            // The compiler emits the following error:
+            //     error CS0571: 'MatchResult.operator false(MatchResult)': cannot explicitly call operator or accessor
+            // Therefore resort to run-time reflection...
+            var method = typeof(MatchResult).GetMethod("op_False");
+            Assert.That(method, Is.Not.Null);
+            var result = (bool?)method!.Invoke(null, new object[] { match });
+
+            if (result == !matched)
+                Assert.Pass();
+            else
+                Assert.Fail();
+        }
     }
 }


### PR DESCRIPTION
Add operator overloading for `!`, `true` and `false`, which allow `MatchResult` to be treated like a Boolean to test for match/mismatch without needing to go over the `Matched` property value for the same purpose. I'll admit this is a very small syntactic win for now, but it seems like a natural extension as well as allowing for a natural and canonical usage.
