### PR TITLE
Remove conflicting ReShaper settings

### DIFF
--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj.DotSettings
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj.DotSettings
@@ -1,2 +1,0 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp40</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR removes a ReSharper settings file that had the C# language level set to 4.0 for the test project and which conflicts with the globally set version in `Directory.Build.props`:

https://github.com/docopt/docopt.net/blob/2ac84371d949b3b98444817b9580e3ff72e2b45a/Directory.Build.props#L4

Since the file contained only a single setting, the entire file is being removed. It seems best to let ReSharper pick up the language version from `Directory.Build.props` so there's a single point of maintenance.
