### PR TITLE
Fix code generation to handle spaces in argument names

### DIFF
--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -30,8 +30,8 @@ namespace DocoptNet
 
         public override string GenerateCode()
         {
-            var s = Name.Replace("<", "").Replace(">", " ").ToLowerInvariant();
-            s = "Arg" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
+            var s = Name.Replace("<", "").Replace(">", "").ToLowerInvariant();
+            s = "Arg" + GenerateCodeHelper.ConvertToPascalCase(s);
 
             if (Value != null && Value.IsList)
             {

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -11,7 +11,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();
-            s = "Cmd" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
+            s = "Cmd" + GenerateCodeHelper.ConvertToPascalCase(s);
             return $"public bool {s} {{ get {{ return _args[\"{Name}\"].IsTrue; }} }}";
         }
 

--- a/src/DocoptNet/GenerateCodeHelper.cs
+++ b/src/DocoptNet/GenerateCodeHelper.cs
@@ -2,14 +2,14 @@ namespace DocoptNet
 {
     static class GenerateCodeHelper
     {
-        public static string ConvertDashesToCamelCase(string s)
+        public static string ConvertToPascalCase(string s)
         {
             // Start with uppercase char
             var makeUpperCase = true;
             var result = "";
             for (var i = 0; i < s.Length; i++)
             {
-                if(s[i] == '-')
+                if(s[i] is '-' or ' ')
                 {
                     makeUpperCase = true;
                     continue;

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -37,7 +37,7 @@ namespace DocoptNet
         public override string GenerateCode()
         {
             var s = Name.ToLowerInvariant();
-            s = "Opt" + GenerateCodeHelper.ConvertDashesToCamelCase(s);
+            s = "Opt" + GenerateCodeHelper.ConvertToPascalCase(s);
 
             if (ArgCount == 0)
             {

--- a/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -5,37 +5,41 @@ namespace DocoptNet.Tests
     [TestFixture]
     public class GenerateCodeHelperTest
     {
-        [Test]
-        public void ConvertDashesToCamelCase_single_dashes()
+        [TestCase('-')]
+        [TestCase(' ')]
+        public void ConvertDashesToCamelCase_single_dashes(char sep)
         {
-            var actual = GenerateCodeHelper.ConvertDashesToCamelCase("string-with-dashes");
+            var actual = GenerateCodeHelper.ConvertToPascalCase("string" + sep + "with" + sep + "dashes");
             Assert.AreEqual("StringWithDashes", actual);
         }
 
-        [Test]
-        public void ConvertDashesToCamelCase_consecutive_dashes()
+        [TestCase('-')]
+        [TestCase(' ')]
+        public void ConvertDashesToCamelCase_consecutive_dashes(char sep)
         {
-            var input = "string--with----dashes";
+            var input = "string" + sep + sep + "with" + sep + sep + sep + sep + "dashes";
             var expected = "StringWithDashes";
-            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
+            var actual = GenerateCodeHelper.ConvertToPascalCase(input);
             Assert.AreEqual(expected, actual);
         }
 
-        [Test]
-        public void ConvertDashesToCamelCase_existing_uppercase_letters()
+        [TestCase('-')]
+        [TestCase(' ')]
+        public void ConvertDashesToCamelCase_existing_uppercase_letters(char sep)
         {
-            var input = "string-With-Dashes";
+            var input = "string" + sep + "With" + sep + "Dashes";
             var expected = "StringWithDashes";
-            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
+            var actual = GenerateCodeHelper.ConvertToPascalCase(input);
             Assert.AreEqual(expected, actual);
         }
 
-        [Test]
-        public void ConvertDashesToCamelCase_all_uppercase_letters()
+        [TestCase('-')]
+        [TestCase(' ')]
+        public void ConvertDashesToCamelCase_all_uppercase_letters(char sep)
         {
-            var input = "STRING-WITH-DASHES";
+            var input = "STRING" + sep + "WITH" + sep + "DASHES";
             var expected = "STRINGWITHDASHES";
-            var actual = GenerateCodeHelper.ConvertDashesToCamelCase(input);
+            var actual = GenerateCodeHelper.ConvertToPascalCase(input);
             Assert.AreEqual(expected, actual);
         }
     }

--- a/tests/DocoptNet.Tests/GenerateCodeTests.cs
+++ b/tests/DocoptNet.Tests/GenerateCodeTests.cs
@@ -16,7 +16,7 @@ namespace DocoptNet.Tests
 
 Usage:
   prog command ARG <myarg> [OPTIONALARG] [-o -s=<arg> --long=ARG --switch-dash]
-  prog command2 ARG <myarg>
+  prog command2 ARG <myarg> <input file>
   prog files FILE...
 
 Options:
@@ -31,13 +31,14 @@ Explanation:
             const string expected = @"
 public bool CmdCommand { get { return _args[""command""].IsTrue; } }
 public string ArgArg { get { return null == _args[""ARG""] ? null : _args[""ARG""].ToString(); } }
-public string ArgMyarg  { get { return null == _args[""<myarg>""] ? null : _args[""<myarg>""].ToString(); } }
+public string ArgMyarg { get { return null == _args[""<myarg>""] ? null : _args[""<myarg>""].ToString(); } }
 public string ArgOptionalarg { get { return null == _args[""OPTIONALARG""] ? null : _args[""OPTIONALARG""].ToString(); } }
 public bool OptO { get { return _args[""-o""].IsTrue; } }
 public string OptS { get { return null == _args[""-s""] ? ""128"" : _args[""-s""].ToString(); } }
 public string OptLong { get { return null == _args[""--long""] ? null : _args[""--long""].ToString(); } }
 public bool OptSwitchDash { get { return _args[""--switch-dash""].IsTrue; } }
 public bool CmdCommand2 { get { return _args[""command2""].IsTrue; } }
+public string ArgInputFile { get { return null == _args[""<input file>""] ? null : _args[""<input file>""].ToString(); } }
 public bool CmdFiles { get { return _args[""files""].IsTrue; } }
 public ArrayList ArgFile { get { return _args[""FILE""].AsList; } }
 ";


### PR DESCRIPTION
As illustrated by a case in the language agnostic tests:

https://github.com/docopt/docopt.net/blob/fc11d06a3263cf5e197764ee25c326ed1ae8c776/tests/LanguageAgnosticTests/testcases.docopt#L891

argument names can contain spaces. However, this leads to an error in the generated property name. This PR fixes the bug by replacing spaces in addition to dashes. It also renames `GenerateCodeHelper.ConvertDashesToCamelCase` to
`GenerateCodeHelper.ConvertToPascalCase` since it converts multiple separators (not just dashes anymore) to "PascalCase" (the correct name for the convention previously) rather "camelCase".