### PR TITLE
Remove members with naïve command line parsing

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -13,13 +13,7 @@ namespace DocoptNet
 
         public IDictionary<string, ValueObject> Apply(string doc)
         {
-            return Apply(doc, new Tokens("", typeof (DocoptInputErrorException)));
-        }
-
-        public IDictionary<string, ValueObject> Apply(string doc, string cmdLine, bool help = true,
-            object version = null, bool optionsFirst = false, bool exit = false)
-        {
-            return Apply(doc, new Tokens(cmdLine, typeof (DocoptInputErrorException)), help, version, optionsFirst, exit);
+            return Apply(doc, new Tokens(Enumerable.Empty<string>(), typeof (DocoptInputErrorException)));
         }
 
         public IDictionary<string, ValueObject> Apply(string doc, ICollection<string> argv, bool help = true,

--- a/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Shipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Shipped.txt
@@ -5,7 +5,6 @@ DocoptNet.CommandNode.CommandNode(string name) -> void
 DocoptNet.Docopt
 DocoptNet.Docopt.Apply(string doc) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Apply(string doc, DocoptNet.Tokens tokens, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
-DocoptNet.Docopt.Apply(string doc, string cmdLine, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Apply(string doc, System.Collections.Generic.ICollection<string> argv, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Docopt() -> void
 DocoptNet.Docopt.GenerateCode(string doc) -> string
@@ -49,7 +48,6 @@ DocoptNet.Tokens.ErrorType.get -> System.Type
 DocoptNet.Tokens.GetEnumerator() -> System.Collections.Generic.IEnumerator<string>
 DocoptNet.Tokens.Move() -> string
 DocoptNet.Tokens.ThrowsInputError.get -> bool
-DocoptNet.Tokens.Tokens(string source, System.Type errorType) -> void
 DocoptNet.Tokens.Tokens(System.Collections.Generic.IEnumerable<string> source, System.Type errorType) -> void
 DocoptNet.ValueObject
 DocoptNet.ValueObject.AsInt.get -> int

--- a/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -5,7 +5,6 @@ DocoptNet.CommandNode.CommandNode(string name) -> void
 DocoptNet.Docopt
 DocoptNet.Docopt.Apply(string doc) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Apply(string doc, DocoptNet.Tokens tokens, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
-DocoptNet.Docopt.Apply(string doc, string cmdLine, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Apply(string doc, System.Collections.Generic.ICollection<string> argv, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
 DocoptNet.Docopt.Docopt() -> void
 DocoptNet.Docopt.GenerateCode(string doc) -> string
@@ -53,7 +52,6 @@ DocoptNet.Tokens.ErrorType.get -> System.Type
 DocoptNet.Tokens.GetEnumerator() -> System.Collections.Generic.IEnumerator<string>
 DocoptNet.Tokens.Move() -> string
 DocoptNet.Tokens.ThrowsInputError.get -> bool
-DocoptNet.Tokens.Tokens(string source, System.Type errorType) -> void
 DocoptNet.Tokens.Tokens(System.Collections.Generic.IEnumerable<string> source, System.Type errorType) -> void
 DocoptNet.ValueObject
 DocoptNet.ValueObject.AsInt.get -> int

--- a/src/DocoptNet/Tokens.cs
+++ b/src/DocoptNet/Tokens.cs
@@ -17,12 +17,6 @@ namespace DocoptNet
             _tokens = new Queue<string>(source);
         }
 
-        public Tokens(string source, Type errorType)
-        {
-            _errorType = errorType ?? typeof(DocoptInputErrorException);
-            _tokens = new Queue<string>(source.Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
-        }
-
         public Type ErrorType
         {
             get { return _errorType; }

--- a/tests/DocoptNet.Tests/Extensions.cs
+++ b/tests/DocoptNet.Tests/Extensions.cs
@@ -1,10 +1,26 @@
 namespace DocoptNet.Tests
 {
+    using System;
+    using System.Collections.Generic;
+
     static class Extensions
     {
         public static MatchResult Match(this Pattern pattern, params LeafPattern[] left)
         {
             return PatternMatcher.Match(pattern, left.AsReadOnly());
+        }
+
+        public static IDictionary<string, ValueObject> Apply(this Docopt docopt,
+                                                             string doc, string cmdLine,
+                                                             bool help = true,
+                                                             object version = null,
+                                                             bool optionsFirst = false,
+                                                             bool exit = false)
+        {
+            // A very naive way to split a command line into individual
+            // arguments but good enough for the test cases so far:
+            var argv = cmdLine.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
+            return docopt.Apply(doc, argv, help, version, optionsFirst, exit);
         }
     }
 }

--- a/tests/DocoptNet.Tests/ParseArgvTests.cs
+++ b/tests/DocoptNet.Tests/ParseArgvTests.cs
@@ -1,5 +1,6 @@
 namespace DocoptNet.Tests
 {
+    using System;
     using NUnit.Framework;
 
     [TestFixture]
@@ -10,7 +11,7 @@ namespace DocoptNet.Tests
 
         private Tokens TS(string s)
         {
-            return new Tokens(s, typeof(DocoptInputErrorException));
+            return new Tokens(s.Split((char[])null, StringSplitOptions.RemoveEmptyEntries), typeof(DocoptInputErrorException));
         }
 
         [Test]


### PR DESCRIPTION
Some overloaded members accept a command line string that's split into individual arguments in a naïve way that leads to issues like #41. With this PR, I'd like to recommend removing them entirely. Getting command line parsing right across multiple platforms (let alone a single platform) is a very complex and always disappoints someone so it is best left outside the scope of this library. All members should only accept a collection/array/list of argument strings.

I have removed the members, but happy to mark them as obsolete if don't want to move someone's cheese. 🧀