### PR TITLE
Fix names of test cases for `GenerateCodeHelper.ConvertToPascalCase`

### DIFF
--- a/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -7,7 +7,7 @@ namespace DocoptNet.Tests
     {
         [TestCase('-')]
         [TestCase(' ')]
-        public void ConvertDashesToCamelCase_single_dashes(char sep)
+        public void ConvertToPascalCase_single_dashes(char sep)
         {
             var actual = GenerateCodeHelper.ConvertToPascalCase("string" + sep + "with" + sep + "dashes");
             Assert.AreEqual("StringWithDashes", actual);
@@ -15,7 +15,7 @@ namespace DocoptNet.Tests
 
         [TestCase('-')]
         [TestCase(' ')]
-        public void ConvertDashesToCamelCase_consecutive_dashes(char sep)
+        public void ConvertToPascalCase_consecutive_dashes(char sep)
         {
             var input = "string" + sep + sep + "with" + sep + sep + sep + sep + "dashes";
             var expected = "StringWithDashes";
@@ -25,7 +25,7 @@ namespace DocoptNet.Tests
 
         [TestCase('-')]
         [TestCase(' ')]
-        public void ConvertDashesToCamelCase_existing_uppercase_letters(char sep)
+        public void ConvertToPascalCase_existing_uppercase_letters(char sep)
         {
             var input = "string" + sep + "With" + sep + "Dashes";
             var expected = "StringWithDashes";
@@ -35,7 +35,7 @@ namespace DocoptNet.Tests
 
         [TestCase('-')]
         [TestCase(' ')]
-        public void ConvertDashesToCamelCase_all_uppercase_letters(char sep)
+        public void ConvertToPascalCase_all_uppercase_letters(char sep)
         {
             var input = "STRING" + sep + "WITH" + sep + "DASHES";
             var expected = "STRINGWITHDASHES";


### PR DESCRIPTION
In commit 62bd39f74a1b1601595adf91493e828ebd052b9d that was merge or PR #97, the method `ConvertDashesToCamelCase` of `GenerateCodeHelper` was renamed to `ConvertToPascalCase`, but the name wasn't updated in the names of tests cases.