### PR TITLE
Reuse CI configuration via variable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ configuration: Release
 before_build:
 - dotnet --info
 build_script:
-- cmd: dotnet build --configuration $(configuration)
+- cmd: dotnet build --configuration %CONFIGURATION%
 - cmd: IF NOT EXIST dist MKDIR dist
-- cmd: dotnet pack --configuration $(configuration)
+- cmd: dotnet pack --configuration %CONFIGURATION%
 test_script:
 - cmd: dotnet test
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@ configuration: Release
 before_build:
 - dotnet --info
 build_script:
-- cmd: dotnet build --configuration Release
+- cmd: dotnet build --configuration $(configuration)
 - cmd: IF NOT EXIST dist MKDIR dist
-- cmd: dotnet pack --configuration Release
+- cmd: dotnet pack --configuration $(configuration)
 test_script:
 - cmd: dotnet test
 artifacts:


### PR DESCRIPTION
This PR reuses the `configuration` setting via the `$(configuration)` variable so future updates or additions to configuration don't require replacements across the YAML file.