### PR TITLE
Fix build errors

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -171,8 +171,8 @@ namespace DocoptNet
                 select p switch
                 {
                     Command command   => (true, Value: commandSelector(command.Name)),
-                    Argument argument => (true, Value: argumentSelector(argument.Name, argument.Value)),
-                    Option option     => (true, Value: optionSelector(option.LongName, option.ShortName, option.ArgCount, option.Value)),
+                    Argument argument => (true, Value: argumentSelector(argument.Name, new ValueObject(argument.Value.Box))),
+                    Option option     => (true, Value: optionSelector(option.LongName, option.ShortName, option.ArgCount, new ValueObject(option.Value.Box))),
                     _ => default,
                 }
                 into p

--- a/src/DocoptNet/StringList.cs
+++ b/src/DocoptNet/StringList.cs
@@ -43,7 +43,7 @@ namespace DocoptNet
         public StringList Push(string value) => new(value, this);
         public StringList Reverse() => this.Aggregate(Empty, (stack, item) => stack.Push(item));
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             Equals(obj as StringList);
 
         public bool Equals(StringList? other)


### PR DESCRIPTION
Fixes the following build errors (see also issue #106):
 
    DocoptNet\Docopt.cs(174,88): error CS1503: Argument 2: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(175,123): error CS1503: Argument 4: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(174,88): error CS1503: Argument 2: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(175,123): error CS1503: Argument 4: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(174,88): error CS1503: Argument 2: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(175,123): error CS1503: Argument 4: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(182,20): error CS8619: Nullability of reference types in value of type 'TSource[]' doesn't match target type 'IEnumerable<T>'.
    DocoptNet\Docopt.cs(174,88): error CS1503: Argument 2: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
    DocoptNet\Docopt.cs(175,123): error CS1503: Argument 4: cannot convert from 'DocoptNet.Value' to 'DocoptNet.ValueObject'
