### PR TITLE
Remove `Tokens` from public API

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -22,7 +22,7 @@ namespace DocoptNet
             return Apply(doc, new Tokens(argv, typeof (DocoptInputErrorException)), help, version, optionsFirst, exit);
         }
 
-        protected IDictionary<string, ValueObject> Apply(string doc, Tokens tokens,
+        IDictionary<string, ValueObject> Apply(string doc, Tokens tokens,
             bool help = true,
             object version = null, bool optionsFirst = false, bool exit = false)
         {

--- a/src/DocoptNet/Public.cs
+++ b/src/DocoptNet/Public.cs
@@ -12,7 +12,6 @@ namespace DocoptNet
     public partial class OptionNode { }
     public partial class CommandNode { }
     public partial class Node { }
-    public partial class Tokens { }
     public partial class ValueObject { }
 }
 

--- a/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Unshipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard1.5/PublicAPI.Unshipped.txt
@@ -1,0 +1,11 @@
+*REMOVED*DocoptNet.Docopt.Apply(string doc, DocoptNet.Tokens tokens, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
+*REMOVED*DocoptNet.Tokens
+*REMOVED*DocoptNet.Tokens.CreateException(string message) -> System.Exception
+*REMOVED*DocoptNet.Tokens.Current() -> string
+*REMOVED*DocoptNet.Tokens.ErrorType.get -> System.Type
+*REMOVED*DocoptNet.Tokens.GetEnumerator() -> System.Collections.Generic.IEnumerator<string>
+*REMOVED*DocoptNet.Tokens.Move() -> string
+*REMOVED*DocoptNet.Tokens.ThrowsInputError.get -> bool
+*REMOVED*DocoptNet.Tokens.Tokens(System.Collections.Generic.IEnumerable<string> source, System.Type errorType) -> void
+*REMOVED*override DocoptNet.Tokens.ToString() -> string
+*REMOVED*static DocoptNet.Tokens.FromPattern(string pattern) -> DocoptNet.Tokens

--- a/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,11 @@
+*REMOVED*DocoptNet.Docopt.Apply(string doc, DocoptNet.Tokens tokens, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
+*REMOVED*DocoptNet.Tokens
+*REMOVED*DocoptNet.Tokens.CreateException(string message) -> System.Exception
+*REMOVED*DocoptNet.Tokens.Current() -> string
+*REMOVED*DocoptNet.Tokens.ErrorType.get -> System.Type
+*REMOVED*DocoptNet.Tokens.GetEnumerator() -> System.Collections.Generic.IEnumerator<string>
+*REMOVED*DocoptNet.Tokens.Move() -> string
+*REMOVED*DocoptNet.Tokens.ThrowsInputError.get -> bool
+*REMOVED*DocoptNet.Tokens.Tokens(System.Collections.Generic.IEnumerable<string> source, System.Type errorType) -> void
+*REMOVED*override DocoptNet.Tokens.ToString() -> string
+*REMOVED*static DocoptNet.Tokens.FromPattern(string pattern) -> DocoptNet.Tokens

--- a/src/DocoptNet/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/DocoptNet/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,11 @@
+*REMOVED*DocoptNet.Docopt.Apply(string doc, DocoptNet.Tokens tokens, bool help = true, object version = null, bool optionsFirst = false, bool exit = false) -> System.Collections.Generic.IDictionary<string, DocoptNet.ValueObject>
+*REMOVED*DocoptNet.Tokens
+*REMOVED*DocoptNet.Tokens.CreateException(string message) -> System.Exception
+*REMOVED*DocoptNet.Tokens.Current() -> string
+*REMOVED*DocoptNet.Tokens.ErrorType.get -> System.Type
+*REMOVED*DocoptNet.Tokens.GetEnumerator() -> System.Collections.Generic.IEnumerator<string>
+*REMOVED*DocoptNet.Tokens.Move() -> string
+*REMOVED*DocoptNet.Tokens.ThrowsInputError.get -> bool
+*REMOVED*DocoptNet.Tokens.Tokens(System.Collections.Generic.IEnumerable<string> source, System.Type errorType) -> void
+*REMOVED*override DocoptNet.Tokens.ToString() -> string
+*REMOVED*static DocoptNet.Tokens.FromPattern(string pattern) -> DocoptNet.Tokens


### PR DESCRIPTION
I am not sure what the purpose of exposing `Tokens` was (perhaps for unit testing?), but it doesn't seem to add any value or abstraction to the public API and could add burden for on-going maintenance. With this PR, I'd like to recommend removing it from public visibility before the next release and going 1.0.