### PR TITLE
Refine `IApplicationResultAccumulator` to be a pure accumulator

### DIFF
--- a/src/DocoptNet.Playground/Pages/Index.razor
+++ b/src/DocoptNet.Playground/Pages/Index.razor
@@ -168,7 +168,7 @@ Options:
                                      (name, _, _, _, value) => new Node(name, value.Kind, 0, Value.None))
                            .GroupBy(e => e.Name, e => e, (_, g) => new Node(g.First().Name, g.First().ValueKind, g.Count(), Value.None))
                            .ToList();
-            _args = docopt.Apply(_input, argv, help: false, version: null, optionsFirst: false, exit: false, accumulator: ApplicationResultAccumulators.ValueDictionary);
+            _args = docopt.Apply(_input, argv.AsEnumerable(), help: false, version: null, optionsFirst: false, exit: false).ToValueDictionary();
             _nodes = _nodes.Select(n => new Node(n.Name, n.ValueKind, n.Count, _args.TryGetValue(n.Name, out var v) ? v : Value.None)).ToList();
 			_output = string.Empty;
             _output = sb.ToString();

--- a/src/DocoptNet/ApplicationResult.cs
+++ b/src/DocoptNet/ApplicationResult.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+namespace DocoptNet
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    sealed class ApplicationResult
+    {
+        readonly ReadOnlyList<LeafPattern> _collected;
+
+        public ApplicationResult(ReadOnlyList<LeafPattern> collected) => _collected = collected;
+
+        public TResult Accumulate<TState, TResult>(TState initialState,
+                                                   IApplicationResultAccumulator<TState, TResult> accumulator) =>
+            _collected.Aggregate(initialState, (state, p) => (p, p.Value.Object) switch
+                                 {
+                                     (Command , bool v       ) => accumulator.Command(state, p.Name, v),
+                                     (Command , int v        ) => accumulator.Command(state, p.Name, v),
+                                     (Argument, null         ) => accumulator.Argument(state, p.Name),
+                                     (Argument, string v     ) => accumulator.Argument(state, p.Name, v),
+                                     (Argument, StringList v ) => accumulator.Argument(state, p.Name, v.Reverse()),
+                                     (Option  , bool v       ) => accumulator.Option(state, p.Name, v),
+                                     (Option  , int v        ) => accumulator.Option(state, p.Name, v),
+                                     (Option  , string v     ) => accumulator.Option(state, p.Name, v),
+                                     (Option  , null         ) => accumulator.Option(state, p.Name),
+                                     (Option  , StringList v ) => accumulator.Option(state, p.Name, v.Reverse()),
+                                     var other => throw new NotSupportedException($"Unsupported pattern: {other}"),
+                                 },
+                                 accumulator.GetResult);
+    }
+
+    static class ApplicationResultExtensions
+    {
+        internal static IDictionary<string, ValueObject> ToValueObjectDictionary(this ApplicationResult result) =>
+            result.Accumulate(new Dictionary<string, ValueObject>(), ApplicationResultAccumulators.ValueObjectDictionary);
+
+        internal static IDictionary<string, Value> ToValueDictionary(this ApplicationResult result) =>
+            result.Accumulate(new Dictionary<string, Value>(), ApplicationResultAccumulators.ValueDictionary);
+    }
+}

--- a/src/DocoptNet/ApplicationResult.cs
+++ b/src/DocoptNet/ApplicationResult.cs
@@ -6,37 +6,75 @@ namespace DocoptNet
     using System.Collections.Generic;
     using System.Linq;
 
-    sealed class ApplicationResult
+    abstract class ApplicationResult
     {
-        readonly ReadOnlyList<LeafPattern> _collected;
+        public abstract T Map<T>(Func<SuccessResult, T> successResult,
+                                 Func<ErrorResult, T> errorSelector);
 
-        public ApplicationResult(ReadOnlyList<LeafPattern> collected) => _collected = collected;
+        public sealed class SuccessResult : ApplicationResult
+        {
+            readonly ReadOnlyList<LeafPattern> _collected;
 
-        public TResult Accumulate<TState, TResult>(TState initialState,
-                                                   IApplicationResultAccumulator<TState, TResult> accumulator) =>
-            _collected.Aggregate(initialState, (state, p) => (p, p.Value.Object) switch
-                                 {
-                                     (Command , bool v       ) => accumulator.Command(state, p.Name, v),
-                                     (Command , int v        ) => accumulator.Command(state, p.Name, v),
-                                     (Argument, null         ) => accumulator.Argument(state, p.Name),
-                                     (Argument, string v     ) => accumulator.Argument(state, p.Name, v),
-                                     (Argument, StringList v ) => accumulator.Argument(state, p.Name, v.Reverse()),
-                                     (Option  , bool v       ) => accumulator.Option(state, p.Name, v),
-                                     (Option  , int v        ) => accumulator.Option(state, p.Name, v),
-                                     (Option  , string v     ) => accumulator.Option(state, p.Name, v),
-                                     (Option  , null         ) => accumulator.Option(state, p.Name),
-                                     (Option  , StringList v ) => accumulator.Option(state, p.Name, v.Reverse()),
-                                     var other => throw new NotSupportedException($"Unsupported pattern: {other}"),
-                                 },
-                                 accumulator.GetResult);
+            internal SuccessResult(ReadOnlyList<LeafPattern> collected) => _collected = collected;
+
+            public TResult Accumulate<TState, TResult>(TState initialState,
+                                                       IApplicationResultAccumulator<TState, TResult> accumulator) =>
+                _collected.Aggregate(initialState, (state, p) => (p, p.Value.Object) switch
+                                     {
+                                         (Command , bool v       ) => accumulator.Command(state, p.Name, v),
+                                         (Command , int v        ) => accumulator.Command(state, p.Name, v),
+                                         (Argument, null         ) => accumulator.Argument(state, p.Name),
+                                         (Argument, string v     ) => accumulator.Argument(state, p.Name, v),
+                                         (Argument, StringList v ) => accumulator.Argument(state, p.Name, v.Reverse()),
+                                         (Option  , bool v       ) => accumulator.Option(state, p.Name, v),
+                                         (Option  , int v        ) => accumulator.Option(state, p.Name, v),
+                                         (Option  , string v     ) => accumulator.Option(state, p.Name, v),
+                                         (Option  , null         ) => accumulator.Option(state, p.Name),
+                                         (Option  , StringList v ) => accumulator.Option(state, p.Name, v.Reverse()),
+                                         var other => throw new NotSupportedException($"Unsupported pattern: {other}"),
+                                     },
+                                     accumulator.GetResult);
+
+            public override T Map<T>(Func<SuccessResult, T> successResult,
+                                     Func<ErrorResult, T> errorSelector) =>
+                successResult(this);
+        }
+
+        public sealed class ErrorResult : ApplicationResult
+        {
+            internal ErrorResult(string usage) => Usage = usage;
+
+            public string Usage { get; }
+
+            public override T Map<T>(Func<SuccessResult, T> successResult,
+                                     Func<ErrorResult, T> errorSelector) =>
+                errorSelector(this);
+        }
     }
 
     static class ApplicationResultExtensions
     {
-        internal static IDictionary<string, ValueObject> ToValueObjectDictionary(this ApplicationResult result) =>
-            result.Accumulate(new Dictionary<string, ValueObject>(), ApplicationResultAccumulators.ValueObjectDictionary);
+        internal static T Map<T>(this ApplicationResult result, Func<ApplicationResult.SuccessResult, T> selector)
+        {
+            if (result is null) throw new ArgumentNullException(nameof(result));
 
-        internal static IDictionary<string, Value> ToValueDictionary(this ApplicationResult result) =>
-            result.Accumulate(new Dictionary<string, Value>(), ApplicationResultAccumulators.ValueDictionary);
+            return result.Map(selector, r => throw new DocoptInputErrorException(r.Usage));
+        }
+
+        internal static IDictionary<string, ValueObject> ToValueObjectDictionary(this ApplicationResult result)
+        {
+            if (result is null) throw new ArgumentNullException(nameof(result));
+
+            return result.Map(r => r.Accumulate(new Dictionary<string, ValueObject>(),
+                                                ApplicationResultAccumulators.ValueObjectDictionary));
+        }
+
+        internal static IDictionary<string, Value> ToValueDictionary(this ApplicationResult result)
+        {
+            if (result is null) throw new ArgumentNullException(nameof(result));
+
+            return result.Map(sr => sr.Accumulate(new Dictionary<string, Value>(),
+                                                  ApplicationResultAccumulators.ValueDictionary));
+        }
     }
 }

--- a/src/DocoptNet/ApplicationResult.cs
+++ b/src/DocoptNet/ApplicationResult.cs
@@ -8,7 +8,7 @@ namespace DocoptNet
 
     abstract class ApplicationResult
     {
-        public abstract T Map<T>(Func<SuccessResult, T> successResult,
+        public abstract T Map<T>(Func<SuccessResult, T> successSelector,
                                  Func<ErrorResult, T> errorSelector);
 
         public sealed class SuccessResult : ApplicationResult
@@ -35,9 +35,9 @@ namespace DocoptNet
                                      },
                                      accumulator.GetResult);
 
-            public override T Map<T>(Func<SuccessResult, T> successResult,
+            public override T Map<T>(Func<SuccessResult, T> successSelector,
                                      Func<ErrorResult, T> errorSelector) =>
-                successResult(this);
+                successSelector(this);
         }
 
         public sealed class ErrorResult : ApplicationResult
@@ -46,7 +46,7 @@ namespace DocoptNet
 
             public string Usage { get; }
 
-            public override T Map<T>(Func<SuccessResult, T> successResult,
+            public override T Map<T>(Func<SuccessResult, T> successSelector,
                                      Func<ErrorResult, T> errorSelector) =>
                 errorSelector(this);
         }

--- a/src/DocoptNet/ApplicationResult.cs
+++ b/src/DocoptNet/ApplicationResult.cs
@@ -8,14 +8,14 @@ namespace DocoptNet
 
     abstract class ApplicationResult
     {
-        public abstract T Map<T>(Func<SuccessResult, T> successSelector,
-                                 Func<ErrorResult, T> errorSelector);
+        public abstract T Map<T>(Func<Success, T> successSelector,
+                                 Func<Error, T> errorSelector);
 
-        public sealed class SuccessResult : ApplicationResult
+        public sealed class Success : ApplicationResult
         {
             readonly ReadOnlyList<LeafPattern> _collected;
 
-            internal SuccessResult(ReadOnlyList<LeafPattern> collected) => _collected = collected;
+            internal Success(ReadOnlyList<LeafPattern> collected) => _collected = collected;
 
             public TResult Accumulate<TState, TResult>(TState initialState,
                                                        IApplicationResultAccumulator<TState, TResult> accumulator) =>
@@ -35,26 +35,26 @@ namespace DocoptNet
                                      },
                                      accumulator.GetResult);
 
-            public override T Map<T>(Func<SuccessResult, T> successSelector,
-                                     Func<ErrorResult, T> errorSelector) =>
+            public override T Map<T>(Func<Success, T> successSelector,
+                                     Func<Error, T> errorSelector) =>
                 successSelector(this);
         }
 
-        public sealed class ErrorResult : ApplicationResult
+        public sealed class Error : ApplicationResult
         {
-            internal ErrorResult(string usage) => Usage = usage;
+            internal Error(string usage) => Usage = usage;
 
             public string Usage { get; }
 
-            public override T Map<T>(Func<SuccessResult, T> successSelector,
-                                     Func<ErrorResult, T> errorSelector) =>
+            public override T Map<T>(Func<Success, T> successSelector,
+                                     Func<Error, T> errorSelector) =>
                 errorSelector(this);
         }
     }
 
     static class ApplicationResultExtensions
     {
-        internal static T Map<T>(this ApplicationResult result, Func<ApplicationResult.SuccessResult, T> selector)
+        internal static T Map<T>(this ApplicationResult result, Func<ApplicationResult.Success, T> selector)
         {
             if (result is null) throw new ArgumentNullException(nameof(result));
 

--- a/src/DocoptNet/ApplicationResultAccumulator.cs
+++ b/src/DocoptNet/ApplicationResultAccumulator.cs
@@ -4,9 +4,8 @@ namespace DocoptNet
 {
     using System.Collections.Generic;
 
-    interface IApplicationResultAccumulator<T>
+    interface IApplicationResultAccumulator<T, out TResult>
     {
-        T New();
         T Command(T state, string name, bool value);
         T Command(T state, string name, int value);
         T Argument(T state, string name);
@@ -17,8 +16,10 @@ namespace DocoptNet
         T Option(T state, string name, string value);
         T Option(T state, string name, int value);
         T Option(T state, string name, StringList value);
-        T Error(DocoptBaseException exception);
+        TResult GetResult(T state);
     }
+
+    interface IApplicationResultAccumulator<T> : IApplicationResultAccumulator<T, T> { }
 
     static class ApplicationResultAccumulators
     {
@@ -27,7 +28,6 @@ namespace DocoptNet
 
         sealed class ValueDictionaryAccumulator : IApplicationResultAccumulator<IDictionary<string, Value>>
         {
-            public IDictionary<string, Value> New() => new Dictionary<string, Value>();
             public IDictionary<string, Value> Command(IDictionary<string, Value> state, string name, bool value) => Adding(state, name, value);
             public IDictionary<string, Value> Command(IDictionary<string, Value> state, string name, int value) => Adding(state, name, value);
             public IDictionary<string, Value> Argument(IDictionary<string, Value> state, string name) => Adding(state, name, Value.None);
@@ -38,7 +38,8 @@ namespace DocoptNet
             public IDictionary<string, Value> Option(IDictionary<string, Value> state, string name, string value) => Adding(state, name, value);
             public IDictionary<string, Value> Option(IDictionary<string, Value> state, string name, int value) => Adding(state, name, value);
             public IDictionary<string, Value> Option(IDictionary<string, Value> state, string name, StringList value) => Adding(state, name, value);
-            public IDictionary<string, Value> Error(DocoptBaseException exception) => null!;
+
+            public IDictionary<string, Value> GetResult(IDictionary<string, Value> state) => state;
 
             static IDictionary<string, Value> Adding(IDictionary<string, Value> dict, string name, Value value)
             {
@@ -49,7 +50,6 @@ namespace DocoptNet
 
         sealed class ValueObjectDictionaryAccumulator : IApplicationResultAccumulator<IDictionary<string, ValueObject>>
         {
-            public IDictionary<string, ValueObject> New() => new Dictionary<string, ValueObject>();
             public IDictionary<string, ValueObject> Command(IDictionary<string, ValueObject> state, string name, bool value) => Adding(state, name, value);
             public IDictionary<string, ValueObject> Command(IDictionary<string, ValueObject> state, string name, int value) => Adding(state, name, value);
             public IDictionary<string, ValueObject> Argument(IDictionary<string, ValueObject> state, string name) => Adding(state, name, null);
@@ -60,7 +60,8 @@ namespace DocoptNet
             public IDictionary<string, ValueObject> Option(IDictionary<string, ValueObject> state, string name, string value) => Adding(state, name, value);
             public IDictionary<string, ValueObject> Option(IDictionary<string, ValueObject> state, string name, int value) => Adding(state, name, value);
             public IDictionary<string, ValueObject> Option(IDictionary<string, ValueObject> state, string name, StringList value) => Adding(state, name, value);
-            public IDictionary<string, ValueObject> Error(DocoptBaseException exception) => null!;
+
+            public IDictionary<string, ValueObject> GetResult(IDictionary<string, ValueObject> state) => state;
 
             static IDictionary<string, ValueObject> Adding(IDictionary<string, ValueObject> dict, string name, object? value)
             {

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -44,7 +44,7 @@ namespace DocoptNet
 
                 var result = partialResult.Apply();
 
-                return result is ApplicationResult.ErrorResult { Usage: var exitUsage }
+                return result is ApplicationResult.Error { Usage: var exitUsage }
                      ? throw new DocoptInputErrorException(exitUsage)
                      : result;
             }
@@ -102,8 +102,8 @@ namespace DocoptNet
 
             public ApplicationResult Apply() =>
                 _pattern.Fix().Match(_arguments) is (true, { Count: 0 }, var collected)
-                    ? new ApplicationResult.SuccessResult(_pattern.Flat().OfType<LeafPattern>().Concat(collected).ToReadOnlyList())
-                    : new ApplicationResult.ErrorResult(_exitUsage);
+                    ? new ApplicationResult.Success(_pattern.Flat().OfType<LeafPattern>().Concat(collected).ToReadOnlyList())
+                    : new ApplicationResult.Error(_exitUsage);
         }
 
         // TODO consider consolidating duplication with portions of Apply above

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -34,15 +34,15 @@ namespace DocoptNet
             {
                 SetDefaultPrintExitHandlerIfNecessary(exit);
 
-                var partialResult = Parse(doc, tokens, optionsFirst);
+                var parsedResult = Parse(doc, tokens, optionsFirst);
 
-                if (help && partialResult.IsHelpOptionSpecified)
+                if (help && parsedResult.IsHelpOptionSpecified)
                     OnPrintExit(doc);
 
-                if (version is not null && partialResult.IsVersionOptionSpecified)
+                if (version is not null && parsedResult.IsVersionOptionSpecified)
                     OnPrintExit(version.ToString());
 
-                return partialResult.Apply();
+                return parsedResult.Apply();
             }
             catch (DocoptBaseException e)
             {

--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -42,11 +42,7 @@ namespace DocoptNet
                 if (version is not null && partialResult.IsVersionOptionSpecified)
                     OnPrintExit(version.ToString());
 
-                var result = partialResult.Apply();
-
-                return result is ApplicationResult.Error { Usage: var exitUsage }
-                     ? throw new DocoptInputErrorException(exitUsage)
-                     : result;
+                return partialResult.Apply();
             }
             catch (DocoptBaseException e)
             {
@@ -102,8 +98,8 @@ namespace DocoptNet
 
             public ApplicationResult Apply() =>
                 _pattern.Fix().Match(_arguments) is (true, { Count: 0 }, var collected)
-                    ? new ApplicationResult.Success(_pattern.Flat().OfType<LeafPattern>().Concat(collected).ToReadOnlyList())
-                    : new ApplicationResult.Error(_exitUsage);
+                    ? new ApplicationResult(_pattern.Flat().OfType<LeafPattern>().Concat(collected).ToReadOnlyList())
+                    : throw new DocoptInputErrorException(_exitUsage);
         }
 
         // TODO consider consolidating duplication with portions of Apply above

--- a/src/DocoptNet/ReadOnlyList.cs
+++ b/src/DocoptNet/ReadOnlyList.cs
@@ -4,9 +4,11 @@ namespace DocoptNet
 {
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
 
     static class ReadOnlyList
     {
+        public static ReadOnlyList<T> ToReadOnlyList<T>(this IEnumerable<T> sequence) => AsReadOnly(sequence.ToList());
         public static ReadOnlyList<T> AsReadOnly<T>(this IList<T> list) => new(list);
     }
 

--- a/tests/DocoptNet.Tests/ApplicationResultAccumulator.cs
+++ b/tests/DocoptNet.Tests/ApplicationResultAccumulator.cs
@@ -13,16 +13,9 @@ namespace DocoptNet.Tests
             static readonly IApplicationResultAccumulator<IDictionary<string, ValueObject>> Accumulator = ApplicationResultAccumulators.ValueObjectDictionary;
 
             [Test]
-            public void New_returns_empty_dictionary()
-            {
-                var dict = Accumulator.New();
-                Assert.That(dict, Is.Empty);
-            }
-
-            [Test]
             public void Command_adds_entry_with_value_converted_to_object()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, ValueObject> dict = new Dictionary<string, ValueObject>();
                 dict = Accumulator.Command(dict, "command", true);
                 var value = dict["command"];
                 Assert.That(value, Is.InstanceOf<ValueObject>());
@@ -32,7 +25,7 @@ namespace DocoptNet.Tests
             [Test]
             public void Argument_adds_entry_with_value_converted_to_object()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, ValueObject> dict = new Dictionary<string, ValueObject>();
                 dict = Accumulator.Argument(dict, "<argument>", "value");
                 var value = dict["<argument>"];
                 Assert.That(value, Is.InstanceOf<ValueObject>());
@@ -42,7 +35,7 @@ namespace DocoptNet.Tests
             [Test]
             public void Option_adds_entry_with_value_converted_to_object()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, ValueObject> dict = new Dictionary<string, ValueObject>();
                 dict = Accumulator.Option(dict, "--option", "value");
                 var value = dict["--option"];
                 Assert.That(value, Is.InstanceOf<ValueObject>());
@@ -50,9 +43,10 @@ namespace DocoptNet.Tests
             }
 
             [Test]
-            public void Error_returns_null()
+            public void GetResult_returns_same()
             {
-                Assert.That(Accumulator.Error(new DocoptInputErrorException()), Is.Null);
+                IDictionary<string, ValueObject> dict = new Dictionary<string, ValueObject>();
+                Assert.That(Accumulator.GetResult(dict), Is.SameAs(dict));
             }
         }
 
@@ -62,16 +56,9 @@ namespace DocoptNet.Tests
             static readonly IApplicationResultAccumulator<IDictionary<string, Value>> Accumulator = ApplicationResultAccumulators.ValueDictionary;
 
             [Test]
-            public void New_returns_empty_dictionary()
-            {
-                var dict = Accumulator.New();
-                Assert.That(dict, Is.Empty);
-            }
-
-            [Test]
             public void Command_adds_entry_with_value()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, Value> dict = new Dictionary<string, Value>();
                 dict = Accumulator.Command(dict, "command", true);
                 var value = dict["command"];
                 Assert.That(value, Is.InstanceOf<Value>());
@@ -81,7 +68,7 @@ namespace DocoptNet.Tests
             [Test]
             public void Argument_adds_entry_with_value()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, Value> dict = new Dictionary<string, Value>();
                 dict = Accumulator.Argument(dict, "<argument>", "value");
                 var value = dict["<argument>"];
                 Assert.That(value, Is.InstanceOf<Value>());
@@ -91,7 +78,7 @@ namespace DocoptNet.Tests
             [Test]
             public void Option_adds_entry_with_value()
             {
-                var dict = Accumulator.New();
+                IDictionary<string, Value> dict = new Dictionary<string, Value>();
                 dict = Accumulator.Option(dict, "--option", "value");
                 var value = dict["--option"];
                 Assert.That(value, Is.InstanceOf<Value>());
@@ -99,9 +86,10 @@ namespace DocoptNet.Tests
             }
 
             [Test]
-            public void Error_returns_null()
+            public void GetResult_returns_same()
             {
-                Assert.That(Accumulator.Error(new DocoptInputErrorException()), Is.Null);
+                IDictionary<string, Value> dict = new Dictionary<string, Value>();
+                Assert.That(Accumulator.GetResult(dict), Is.SameAs(dict));
             }
         }
     }

--- a/tests/DocoptNet.Tests/Extensions.cs
+++ b/tests/DocoptNet.Tests/Extensions.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     static class Extensions
     {
@@ -27,7 +28,8 @@ namespace DocoptNet.Tests
                                                        bool optionsFirst = false,
                                                        bool exit = false)
         {
-            return docopt.Apply(doc, argv.List, ApplicationResultAccumulators.ValueDictionary, help, version, optionsFirst, exit);
+            return docopt.Apply(doc, argv.List.AsEnumerable(), help, version, optionsFirst, exit)
+                        ?.ToValueDictionary();
         }
     }
 


### PR DESCRIPTION
This PR remove new-ing (`New`) and error (`Error`) responsibilities from `IApplicationResultAccumulator<>`, making it a pure accumulator interface as far as arguments go:

```c#
interface IApplicationResultAccumulator<T, out TResult>
{
    T Command(T state, string name, bool value);
    T Command(T state, string name, int value);
    T Argument(T state, string name);
    T Argument(T state, string name, string value);
    T Argument(T state, string name, StringList value);
    T Option(T state, string name);
    T Option(T state, string name, bool value);
    T Option(T state, string name, string value);
    T Option(T state, string name, int value);
    T Option(T state, string name, StringList value);
    TResult GetResult(T state);
}
```

This has the benefit that an accumulator doesn't have to enforce constraints like `new()` or return `null` from `Error`.

The `GetResult` method and an additional result type parameter (`TResult`) have been added to allow the state type (`T`) and result type (`TResult`) to vary as well as for implementations to do a final validation/conversion if needed.

A more subtle benefit of this is that the core implementation (still private) is now static (see `Docopt.Parse`).

