### PR TITLE
Test and fix issue #32

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -317,9 +317,8 @@ namespace DocoptNet
                 var atom = ParseAtom(tokens, options);
                 if (tokens.Current() == "...")
                 {
-                    result.Add(new OneOrMore(atom.ToArray()));
+                    atom = new[] { new OneOrMore(atom.ToArray()) };
                     tokens.Move();
-                    return result;
                 }
                 result.AddRange(atom);
             }

--- a/tests/DocoptNet.Tests/DocoptTests.cs
+++ b/tests/DocoptNet.Tests/DocoptTests.cs
@@ -204,5 +204,16 @@ namespace DocoptNet.Tests
             Assert.True(args["-x"].IsTrue);
             Assert.True(args["-y"].IsFalse);
         }
+
+        [Test]
+        public void Test_issue_32_should_parse()
+        {
+            const string doc = @"
+Usage: Conversion (load | brokers | loadnonxl | <pn>... [--clean]) [--whatif]
+
+-h --help    show this
+--verbose    print more text";
+            Assert.DoesNotThrow(() => new Docopt().Apply(doc, "dfg67 dfg4 dg2 --clean"));
+        }
     }
 }


### PR DESCRIPTION
This PR addresses the bug reported in issue #32. It seems that the C# port had an interpretation error of [`parse_seq` in the reference Python reference implementation](https://github.com/docopt/docopt/blob/6879155f77855ea29977ccb96ad6bc09b55d567f/docopt.py#L390-L399).
