### PR TITLE
Display tree in Blazor app on error (if possible)

### DIFF
--- a/src/DocoptNet.Playground/Pages/Index.razor
+++ b/src/DocoptNet.Playground/Pages/Index.razor
@@ -138,13 +138,12 @@ Options:
         _lastOptionsFirst = _optionsFirst;
         _lastInput = _input;
         _lastCommandLine = _commandLine;
+        _output = string.Empty;
         _error = false;
         _ms = null;
 
-        if (_input.Length == 0) {
-            _output = string.Empty;
+        if (_input.Length == 0)
             return;
-        }
 
         var sw = Stopwatch.StartNew();
 
@@ -169,6 +168,7 @@ Options:
             var sb = new StringBuilder();
             var (pattern, _, _) = Docopt.ParsePattern(_input);
             AppendTree(sb, pattern);
+            _output = sb.ToString();
 
             var docopt = new Docopt();
             var argv = _commandLine.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
@@ -180,15 +180,17 @@ Options:
                            .ToList();
             _args = docopt.Apply(_input, argv.AsEnumerable(), help: false, version: null, optionsFirst: _optionsFirst, exit: false).ToValueDictionary();
             _nodes = _nodes.Select(n => new Node(n.Name, n.ValueKind, n.Count, _args.TryGetValue(n.Name, out var v) ? v : Value.None)).ToList();
-            _output = string.Empty;
-            _output = sb.ToString();
             _ms = sw.Elapsed;
         }
         catch (DocoptBaseException e)
         {
             _args = null;
-            _output = e.Message;
+            var width = _output.Split(NewLineChars, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Length).DefaultIfEmpty().Max();
+            var ruler = new string('=', width);
+            _output = $"{e.Message.TrimEnd()}\r\n\r\n{ruler}\r\n{_output}";
             _error = true;
         }
     }
+
+    static readonly char[] NewLineChars = { '\r', '\n' };
 }


### PR DESCRIPTION
Up to now, if there was an input error, the whole pattern tree would be replaced with the error message or usage. With this PR, if the pattern tree can be displayed (e.g. the specification was successfully parsed but the arguments don't match) then it is appended after the error/usage message (with a ruler made of `=` dividing the two).

    Usage:
    naval_fate ship new <name>...
    naval_fate ship <name> move <x> <y> [--speed=<kn>]
    naval_fate ship shoot <x> <y>
    naval_fate mine (set|remove) <x> <y> [--moored|--drifting]
    naval_fate -h | --help
    naval_fate --version

    =====================================
    Required:
    Either:
        Required:
        Command(ship, False)
        Command(new, False)
        OneOrMore:
            Argument(<name>, [])
        Required:
        Command(ship, False)
        Argument(<name>, [])
        Command(move, False)
        Argument(<x>, )
        Argument(<y>, )
        Optional:
            Option(,--speed,1,10)
        Required:
        Command(ship, False)
        Command(shoot, False)
        Argument(<x>, )
        Argument(<y>, )
        Required:
        Command(mine, False)
        Required:
            Either:
            Command(set, False)
            Command(remove, False)
        Argument(<x>, )
        Argument(<y>, )
        Optional:
            Either:
            Option(,--moored,0,False)
            Option(,--drifting,0,False)
        Required:
        Option(-h,--help,0,False)
        Required:
        Option(,--version,0,False)
