### PR TITLE
Remove redundant build props in examples

### DIFF
--- a/eg/SourceGenerator/Git/Git.csproj
+++ b/eg/SourceGenerator/Git/Git.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
-    <DebugDocoptNet>false</DebugDocoptNet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eg/SourceGenerator/NavalFate/NavalFate.csproj
+++ b/eg/SourceGenerator/NavalFate/NavalFate.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)Generated</CompilerGeneratedFilesOutputPath>
-    <DebugDocoptNet>false</DebugDocoptNet>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some examples had build properties redundant with those in `eg/SourceGenerator/Directory.Build.props`. This PR removes them.