### PR TITLE
Fix assembly version

### DIFF
--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -20,8 +20,6 @@
     <IsPackable>true</IsPackable>
     <Copyright>Copyright (c) 2013 Dinh Doan Van Bien, dinh@doanvanbien.com</Copyright>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PackageId>docopt.net</PackageId>
     <PackageLicenseUrl>https://github.com/docopt/docopt.net/blob/master/LICENSE-MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/docopt/docopt.net</PackageProjectUrl>


### PR DESCRIPTION
This PR fixes issue #122.

After applying this PR, the fix can be validated either in a PowerShell session:

    ❯ Get-ChildItem -Recurse -File -Filter DocoptNet.dll src\DocoptNet\bin | % { $_.VersionInfo }

    ProductVersion   FileVersion      FileName
    --------------   -----------      --------
    0.6.1.11         0.6.1.11         A:\docopt\dotnet\main\src\DocoptNet\bin\Debug\netstandard1.5\DocoptNet.dll
    0.6.1.11         0.6.1.11         A:\docopt\dotnet\main\src\DocoptNet\bin\Debug\netstandard2.0\DocoptNet.dll
    0.6.1.11         0.6.1.11         A:\docopt\dotnet\main\src\DocoptNet\bin\Debug\netstandard2.1\DocoptNet.dll

or in a [dotnet-script](https://www.nuget.org/packages/dotnet-script) session:

    ❯ dotnet script
    > #r "src\DocoptNet\bin\Debug\netstandard2.1\DocoptNet.dll"
    > typeof(DocoptNet.Docopt).Assembly
    [DocoptNet, Version=0.6.1.11, Culture=neutral, PublicKeyToken=7a38c71da49a547e]
