### PR TITLE
Fix warnings (treating as errors) in tested compilations

### DIFF
--- a/tests/DocoptNet.Tests/CodeGeneration/LanguageAgnosticTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/LanguageAgnosticTests.cs
@@ -30,8 +30,6 @@ using Newtonsoft.Json;
 
 public partial class Program
 {
-    readonly IDictionary<string, Value> _args;
-
     public Program(IList<string> argv)
     {
         var arguments = ProgramArguments.Apply(argv, help: true, version: null, optionsFirst: false);

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
@@ -398,7 +398,8 @@ namespace DocoptNet
         {
             var references =
                 from asm in AppDomain.CurrentDomain.GetAssemblies()
-                where !asm.IsDynamic && !string.IsNullOrWhiteSpace(asm.Location)
+                where asm is { IsDynamic: false, Location: { Length: > 0 } }
+                   && asm.GetName().Name != "DocoptNet"
                 select MetadataReference.CreateFromFile(asm.Location);
 
             var trees = new List<SyntaxTree>();
@@ -417,7 +418,8 @@ namespace DocoptNet
             var compilation =
                 CSharpCompilation.Create(FormattableString.Invariant($"test{Interlocked.Increment(ref _assemblyUniqueCounter)}"),
                                          trees, references,
-                                         new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                                         new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                                                                      generalDiagnosticOption: ReportDiagnostic.Error));
 
             ISourceGenerator generator = new SourceGenerator();
 


### PR DESCRIPTION
Several warnings about conflicting types were going unnoticed in tested compilations. This PR treats all warnings as errors and addresses them by principally avoiding a reference to the `DocoptNet` assembly.