### PR TITLE
Use whitelist of references for test compilations

### DIFF
--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Basic.Reference.Assemblies" Version="1.2.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
So far, the test compilations would reference all assemblies from the current domain and then blacklist some. This PR changes the strategy to use a whitelist of references. The framework references are pulled in via [Basic.Reference.Assemblies]. This prevents duplicate warnings from compiler when it finds duplicate definitions due to embedded sources.

[Basic.Reference.Assemblies]: https://www.nuget.org/packages/Basic.Reference.Assemblies