### PR TITLE
Consistently omit (unnecessary) `this.` qualification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,6 +33,12 @@ indent_size = 4
 [*.cs]
 csharp_using_directive_placement = inside_namespace
 
+# this. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion

--- a/src/DocoptNet/Argument.cs
+++ b/src/DocoptNet/Argument.cs
@@ -30,7 +30,7 @@ namespace DocoptNet
 
         public override Node ToNode()
         {
-            return new ArgumentNode(this.Name, Value.IsStringList ? ValueType.List : ValueType.String);
+            return new ArgumentNode(Name, Value.IsStringList ? ValueType.List : ValueType.String);
         }
 
         public override string GenerateCode()

--- a/src/DocoptNet/BranchPatterns.cs
+++ b/src/DocoptNet/BranchPatterns.cs
@@ -28,7 +28,7 @@ namespace DocoptNet
         public override ICollection<Pattern> Flat(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException(nameof(types));
-            if (types.Contains(this.GetType()))
+            if (types.Contains(GetType()))
             {
                 return new Pattern[] { this };
             }

--- a/src/DocoptNet/Command.cs
+++ b/src/DocoptNet/Command.cs
@@ -6,7 +6,7 @@ namespace DocoptNet
         {
         }
 
-        public override Node ToNode() { return new CommandNode(this.Name); }
+        public override Node ToNode() { return new CommandNode(Name); }
 
         public override string GenerateCode()
         {

--- a/src/DocoptNet/LeafPattern.cs
+++ b/src/DocoptNet/LeafPattern.cs
@@ -31,7 +31,7 @@ namespace DocoptNet
         public override ICollection<Pattern> Flat(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException(nameof(types));
-            if (types.Length == 0 || types.Contains(this.GetType()))
+            if (types.Length == 0 || types.Contains(GetType()))
             {
                 return new Pattern[] { this };
             }

--- a/src/DocoptNet/Node.cs
+++ b/src/DocoptNet/Node.cs
@@ -28,8 +28,8 @@ namespace DocoptNet
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
-            this.Name = name;
-            this.ValueType = valueType;
+            Name = name;
+            ValueType = valueType;
         }
 
         public ValueType ValueType { get; private set; }
@@ -42,7 +42,7 @@ namespace DocoptNet
 
         public override int GetHashCode()
         {
-            return this.Name.GetHashCode() ^ this.ValueType.GetHashCode();
+            return Name.GetHashCode() ^ ValueType.GetHashCode();
         }
 
         public bool Equals(Node other)
@@ -57,8 +57,8 @@ namespace DocoptNet
                 return true;
             }
 
-            return other.Name == this.Name
-                && other.ValueType == this.ValueType;
+            return other.Name == Name
+                && other.ValueType == ValueType;
         }
 
         public override bool Equals(object obj)
@@ -73,12 +73,12 @@ namespace DocoptNet
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
+            if (obj.GetType() != GetType())
             {
                 return false;
             }
 
-            return this.Equals((Node)obj);
+            return Equals((Node)obj);
         }
     }
 

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -31,7 +31,7 @@ namespace DocoptNet
 
         public override Node ToNode()
         {
-            return new OptionNode(this.Name.TrimStart('-'), this.ArgCount == 0 ? ValueType.Bool : ValueType.String);
+            return new OptionNode(Name.TrimStart('-'), ArgCount == 0 ? ValueType.Bool : ValueType.String);
         }
 
         public override string GenerateCode()

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Argument.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Argument.cs
@@ -30,7 +30,7 @@ namespace DocoptNet.Generated
 
         public override Node ToNode()
         {
-            return new ArgumentNode(this.Name, Value.IsStringList ? ValueType.List : ValueType.String);
+            return new ArgumentNode(Name, Value.IsStringList ? ValueType.List : ValueType.String);
         }
 
         public override string GenerateCode()

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/BranchPatterns.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/BranchPatterns.cs
@@ -28,7 +28,7 @@ namespace DocoptNet.Generated
         public override ICollection<Pattern> Flat(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException(nameof(types));
-            if (types.Contains(this.GetType()))
+            if (types.Contains(GetType()))
             {
                 return new Pattern[] { this };
             }

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Command.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Command.cs
@@ -6,7 +6,7 @@ namespace DocoptNet.Generated
         {
         }
 
-        public override Node ToNode() { return new CommandNode(this.Name); }
+        public override Node ToNode() { return new CommandNode(Name); }
 
         public override string GenerateCode()
         {

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/LeafPattern.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/LeafPattern.cs
@@ -31,7 +31,7 @@ namespace DocoptNet.Generated
         public override ICollection<Pattern> Flat(params Type[] types)
         {
             if (types == null) throw new ArgumentNullException(nameof(types));
-            if (types.Length == 0 || types.Contains(this.GetType()))
+            if (types.Length == 0 || types.Contains(GetType()))
             {
                 return new Pattern[] { this };
             }

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Node.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Node.cs
@@ -28,8 +28,8 @@ namespace DocoptNet.Generated
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
 
-            this.Name = name;
-            this.ValueType = valueType;
+            Name = name;
+            ValueType = valueType;
         }
 
         public ValueType ValueType { get; private set; }
@@ -42,7 +42,7 @@ namespace DocoptNet.Generated
 
         public override int GetHashCode()
         {
-            return this.Name.GetHashCode() ^ this.ValueType.GetHashCode();
+            return Name.GetHashCode() ^ ValueType.GetHashCode();
         }
 
         public bool Equals(Node other)
@@ -57,8 +57,8 @@ namespace DocoptNet.Generated
                 return true;
             }
 
-            return other.Name == this.Name
-                && other.ValueType == this.ValueType;
+            return other.Name == Name
+                && other.ValueType == ValueType;
         }
 
         public override bool Equals(object obj)
@@ -73,12 +73,12 @@ namespace DocoptNet.Generated
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
+            if (obj.GetType() != GetType())
             {
                 return false;
             }
 
-            return this.Equals((Node)obj);
+            return Equals((Node)obj);
         }
     }
 

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Option.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Option.cs
@@ -31,7 +31,7 @@ namespace DocoptNet.Generated
 
         public override Node ToNode()
         {
-            return new OptionNode(this.Name.TrimStart('-'), this.ArgCount == 0 ? ValueType.Bool : ValueType.String);
+            return new OptionNode(Name.TrimStart('-'), ArgCount == 0 ? ValueType.Bool : ValueType.String);
         }
 
         public override string GenerateCode()


### PR DESCRIPTION
Most of the code base was not using the `this.` qualification. This PR renders the code base consistent by omitting the qualification since it almost never seems to be needed.
