### PR TITLE
Optimise delimiter sets in `String.Split` invocations

### DIFF
--- a/src/DocoptNet/Docopt.cs
+++ b/src/DocoptNet/Docopt.cs
@@ -252,7 +252,7 @@ namespace DocoptNet
         internal static string FormalUsage(string exitUsage)
         {
             var (_, _, section) = exitUsage.Partition(":"); // drop "usage:"
-            var pu = section.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+            var pu = section.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
             var join = new StringBuilder();
             join.Append("( ");
             for (var i = 1; i < pu.Length; i++)

--- a/src/DocoptNet/Option.cs
+++ b/src/DocoptNet/Option.cs
@@ -54,6 +54,8 @@ namespace DocoptNet
 
         private const string DESC_SEPARATOR = "  ";
 
+        static readonly char[] OptionDelimiters = { ' ', '\t', ',', '=' };
+
         public static Option Parse(string optionDescription)
         {
             if (optionDescription == null) throw new ArgumentNullException(nameof(optionDescription));
@@ -63,7 +65,7 @@ namespace DocoptNet
             var argCount = 0;
             var value = Value.False;
             var (options, _, description) = optionDescription.Trim().Partition(DESC_SEPARATOR);
-            foreach (var s in options.Split(" \t,=".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
+            foreach (var s in options.Split(OptionDelimiters, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (s.StartsWith("--"))
                     longName = s;

--- a/src/DocoptNet/Pattern.cs
+++ b/src/DocoptNet/Pattern.cs
@@ -92,7 +92,7 @@ namespace DocoptNet
                         }
                         else if (!e.Value.IsStringList)
                         {
-                            e.Value = StringList.BottomTop(e.Value.ToString().Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
+                            e.Value = StringList.BottomTop(e.Value.ToString().Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
                         }
                     }
                     if (e is Command || e is Option { ArgCount: 0 })

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Docopt.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Docopt.cs
@@ -252,7 +252,7 @@ namespace DocoptNet.Generated
         internal static string FormalUsage(string exitUsage)
         {
             var (_, _, section) = exitUsage.Partition(":"); // drop "usage:"
-            var pu = section.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+            var pu = section.Split((char[])null, StringSplitOptions.RemoveEmptyEntries);
             var join = new StringBuilder();
             join.Append("( ");
             for (var i = 1; i < pu.Length; i++)

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Option.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Option.cs
@@ -54,6 +54,8 @@ namespace DocoptNet.Generated
 
         private const string DESC_SEPARATOR = "  ";
 
+        static readonly char[] OptionDelimiters = { ' ', '\t', ',', '=' };
+
         public static Option Parse(string optionDescription)
         {
             if (optionDescription == null) throw new ArgumentNullException(nameof(optionDescription));
@@ -63,7 +65,7 @@ namespace DocoptNet.Generated
             var argCount = 0;
             var value = Value.False;
             var (options, _, description) = optionDescription.Trim().Partition(DESC_SEPARATOR);
-            foreach (var s in options.Split(" \t,=".ToCharArray(), StringSplitOptions.RemoveEmptyEntries))
+            foreach (var s in options.Split(OptionDelimiters, StringSplitOptions.RemoveEmptyEntries))
             {
                 if (s.StartsWith("--"))
                     longName = s;

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Pattern.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_custom_embedding_namespace/Pattern.cs
@@ -92,7 +92,7 @@ namespace DocoptNet.Generated
                         }
                         else if (!e.Value.IsStringList)
                         {
-                            e.Value = StringList.BottomTop(e.Value.ToString().Split(new char[0], StringSplitOptions.RemoveEmptyEntries));
+                            e.Value = StringList.BottomTop(e.Value.ToString().Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
                         }
                     }
                     if (e is Command || e is Option { ArgCount: 0 })


### PR DESCRIPTION
This PR optimises `String.Split` invocations by avoiding array allocation of the delimiter set (especially in the default case where `new char[0]` or `null` means all whitespace) on each invocation.