### PR TITLE
Drop .NET Core 2.1 runtime testing (end of life)

### DIFF
--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net47</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\src\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>


### PR DESCRIPTION
This PR drops testing on [.NET Core 2.1](https://dotnet.microsoft.com/download/dotnet/2.1) that reached end of support on August 21, 2021.

This only affects testing on that runtime.
