### PR TITLE
Fix upper/lower short option property name conflict

### DIFF
--- a/eg/SourceGenerator/Git/Git.csproj
+++ b/eg/SourceGenerator/Git/Git.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- FIXME Re-enable after addressing CS0102 errors -->
-    <None Remove="GitBranch.docopt.txt" />
-    <None Remove="GitCheckout.docopt.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\..\src\DocoptNet.CodeGeneration\DocoptNet.CodeGeneration.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 

--- a/eg/SourceGenerator/Git/Program.cs
+++ b/eg/SourceGenerator/Git/Program.cs
@@ -44,8 +44,8 @@ static int Run(string[] args)
     // - error CS0102: The type 'GitBranchArguments' already contains a definition for 'OptD'
     // - error CS0102: The type 'GitBranchArguments' already contains a definition for 'OptM'
     // - error CS0102: The type 'GitCheckoutArguments' already contains a definition for 'OptB'
-    // "branch"     => Apply(args => GitBranchArguments.Apply(args)),
-    // "checkout"   => Apply(args => GitCheckoutArguments.Apply(args)),
+        "branch"    => Apply(args => GitBranchArguments.Apply(args)),
+        "checkout"  => Apply(args => GitCheckoutArguments.Apply(args)),
         "clone"     => Apply(args => GitCloneArguments.Apply(args)),
         "commit"    => Apply(args => GitCommitArguments.Apply(args)),
         "push"      => Apply(args => GitPushArguments.Apply(args)),

--- a/src/DocoptNet.CodeGeneration/SourceGenerator.cs
+++ b/src/DocoptNet.CodeGeneration/SourceGenerator.cs
@@ -436,6 +436,7 @@ namespace DocoptNet.CodeGeneration
                 {
                     Command  { Name: var name } => $"Cmd{GenerateCodeHelper.ConvertToPascalCase(name.ToLowerInvariant())}",
                     Argument { Name: var name } => $"Arg{GenerateCodeHelper.ConvertToPascalCase(name.Replace("<", "").Replace(">", "").ToLowerInvariant())}",
+                    Option   { LongName: null, ShortName: var name } when char.IsUpper(name[1]) => $"OptUpper{name[1]}",
                     Option   { Name: var name } => $"Opt{GenerateCodeHelper.ConvertToPascalCase(name.ToLowerInvariant())}",
                     var p => throw new NotSupportedException($"Unsupported pattern: {p}")
                 };


### PR DESCRIPTION
If two options have only short names sharing the same letter, but differ only in case, then the generated code can contain properties with conflicting names. For example, the `git branch` example has the following usage:

    usage: git branch [options] [-r | -a] [--merged=<commit> | --no-merged=<commit>]
           git branch [options] [-l] [-f] <branchname> [<start-point>]
           git branch [options] [-r] (-d | -D) <branchname>
           git branch [options] (-m | -M) [<oldbranch>] <newbranch>

    Generic options
        -h, --help
        -v, --verbose         show hash and subject, give twice for upstream branch
        -t, --track           set up tracking mode (see git-pull(1))
        --set-upstream        change upstream info
        --color=<when>        use colored output
        -r                    act on remote-tracking branches
        --contains=<commit>   print only branches that contain the commit
        --abbrev=<n>          use <n> digits to display SHA-1s

    Specific git-branch actions:
        -a                    list both remote-tracking and local branches
        -d                    delete fully merged branch
        -D                    delete branch (even if not merged)
        -m                    move/rename a branch and its reflog
        -M                    move/rename a branch, even if target exists
        -l                    create the branch's reflog
        -f, --force           force creation (when already exists)
        --no-merged=<commit>  print only not merged branches
        --merged=<commit>     print only merged branches

Note options `-d`, `-D`, `-m` and `-M` only have short names and only differ in case. They will cause identically named properties, namely `OptD` and `OptM`, to be generated on the arguments class _twice_ and the resulting code would lead to a compilation errors. This PR fixes the problem by naming any option without a long name and having a short name that's an uppercase letter with the prefix `OptUpper`.  In the case of options sharing the same letter, the generated properties will be as follows:

- `-d` &rarr; `-OptD`
- `-D` &rarr; `-OptUpperD`
- `-m` &rarr; `-OptM`
- `-M` &rarr; `-OptUpperM`

## Alternative considered

Another option would have been to be more consistent and use the `OptLower` prefix for lowercase short names and `OptUpper` for uppercase short names, as in:

- `-d` &rarr; `-OptLowerD`
- `-D` &rarr; `-OptUpperD`
- `-m` &rarr; `-OptLowerM`
- `-M` &rarr; `-OptUpperM`

However, it's expected that lowercase option names will be more common for small utilities and so having `Lower` in the property name seemed a little excessive.
