### PR TITLE
Put packaging outputs in a directory of redistributable artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,5 @@ build_script:
 test_script:
 - cmd: dotnet test
 artifacts:
-- path: '**\docopt.net*.nupkg'
+- path: 'dist\*.nupkg'
   name: Nuget

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -24,6 +24,7 @@
     <PackageLicenseUrl>https://github.com/docopt/docopt.net/blob/master/LICENSE-MIT</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/docopt/docopt.net</PackageProjectUrl>
     <PackageIconUrl>https://secure.gravatar.com/avatar/e82bc289285e348387313a00cfd84979?s=400&amp;d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png</PackageIconUrl>
+    <PackageOutputPath>..\..\dist</PackageOutputPath>
     <Title>docopt.net, a beautiful command-line parser</Title>
     <Authors>Dinh Doan Van Bien;Vladimir Keleshev</Authors>
     <Description>docopt.net is the .net version of the docopt python beautiful command line parser.  docopt.net helps you define an interface for your command-line app, and automatically generate a parser for it. docopt.net is based on conventions that have been used for decades in help messages and man pages for program interface description.  Interface description in docopt.net is such a help message, but formalized. Check out http://docopt.org for a more detailed explanation.


### PR DESCRIPTION
This PR puts NuGet packages into a `dist` directory in the root of the clone, where they are easy to locate, rather than being buried deep in the directory tree with other binary outputs (e.g. `src\DocoptNet\bin\Debug`).