### PR TITLE
Add Ubuntu to CI images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 1.1.{build}
-image: Visual Studio 2019
+image:
+  - Visual Studio 2019
+  - Ubuntu1604
 skip_commits:
   files:
     - '*.md'
@@ -11,11 +13,11 @@ init:
 before_build:
 - dotnet --info
 build_script:
-- cmd: dotnet build --configuration %CONFIGURATION%
-- cmd: IF NOT EXIST dist MKDIR dist
-- cmd: dotnet pack --configuration %CONFIGURATION%
+- ps: dotnet build --configuration $CONFIGURATION
+- ps: if (!(Test-Path -PathType Container dist)) { New-Item -ItemType Directory temp }
+- ps: if ($isWindows) { dotnet pack --configuration $CONFIGURATION }
 test_script:
-- cmd: dotnet test
+- ps: dotnet test
 artifacts:
 - path: 'dist\*.nupkg'
   name: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,9 @@ init:
 before_build:
 - dotnet --info
 build_script:
-- ps: dotnet build --configuration $CONFIGURATION
+- ps: dotnet build --configuration $env:CONFIGURATION
 - ps: if (!(Test-Path -PathType Container dist)) { New-Item -ItemType Directory temp }
-- ps: if ($isWindows) { dotnet pack --configuration $CONFIGURATION }
+- ps: if ($isWindows) { dotnet pack --configuration $env:CONFIGURATION }
 test_script:
 - ps: dotnet test
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_build:
 - dotnet --info
 build_script:
 - ps: dotnet build --configuration $env:CONFIGURATION
-- ps: if ($isWindows) { dotnet pack --configuration $env:CONFIGURATION }
+- cmd: dotnet pack --configuration %CONFIGURATION%
 test_script:
 - ps: dotnet test
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_build:
 - dotnet --info
 build_script:
 - ps: dotnet build --configuration $env:CONFIGURATION
-- ps: if (!(Test-Path -PathType Container dist)) { New-Item -ItemType Directory temp }
+- ps: if (!(Test-Path -PathType Container dist)) { New-Item -ItemType Directory dist }
 - ps: if ($isWindows) { dotnet pack --configuration $env:CONFIGURATION }
 test_script:
 - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ before_build:
 - dotnet --info
 build_script:
 - ps: dotnet build --configuration $env:CONFIGURATION
-- ps: if (!(Test-Path -PathType Container dist)) { New-Item -ItemType Directory dist }
 - ps: if ($isWindows) { dotnet pack --configuration $env:CONFIGURATION }
 test_script:
 - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ skip_commits:
     - '.git*'
 configuration: Release
 init:
-- git config --global core.autocrlf true
+- cmd: git config --global core.autocrlf true
 before_build:
 - dotnet --info
 build_script:

--- a/src/DocoptNet.CodeGeneration/OptionModule.cs
+++ b/src/DocoptNet.CodeGeneration/OptionModule.cs
@@ -1,0 +1,6 @@
+#nullable enable
+
+static class OptionModule
+{
+    public static (bool HasValue, T Value) Some<T>(T value) => (true, value);
+}

--- a/src/DocoptNet.CodeGeneration/OptionModule.cs
+++ b/src/DocoptNet.CodeGeneration/OptionModule.cs
@@ -1,6 +1,0 @@
-#nullable enable
-
-static class OptionModule
-{
-    public static (bool HasValue, T Value) Some<T>(T value) => (true, value);
-}


### PR DESCRIPTION
This PR adds Ubuntu to set of images for which CI is run and the solution built & tested.

Note that packaging is done on Windows only and PowerShell is used for portability.
