### PR TITLE
Use commit timestamp as a version suffix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,12 @@ init:
 before_build:
 - dotnet --info
 build_script:
-- ps: dotnet build --configuration $env:CONFIGURATION
-- cmd: dotnet pack --configuration %CONFIGURATION%
+- ps: |
+    dotnet build --configuration $env:CONFIGURATION
+    if ($isWindows) {
+      $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
+      dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
+    }
 test_script:
 - ps: dotnet test
 artifacts:


### PR DESCRIPTION
This PR will use the commit timestamp as the version suffix. This has the effect of generating a unique version of the NuGet version that's tied to the commit, which can be handy for preview/nightly feeds. If commit time is **Thu Dec 23 19:30:48 2021 +0100**, then the version suffix will be `20211223t1830` in UTC.