### PR TITLE
Enable reproducible builds with Source Link support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "dotnet-script"
       ]
+    },
+    "sourcelink": {
+      "version": "3.1.1",
+      "commands": [
+        "sourcelink"
+      ]
     }
   }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
-      Get-ChildItem -File -Filter docopt.net.*.nupkg dist | % { dotnet sourcelink test $_ }
+      Get-ChildItem -File -Filter docopt.net.*.nupkg dist | % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }
     }
 test_script:
 - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
-      dotnet sourcelink test (Get-ChildItem -File -Filter docopt.net.*.nupkg dist)
+      Get-ChildItem -File -Filter docopt.net.*.nupkg dist | % { dotnet sourcelink test $_ }
     }
 test_script:
 - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,14 @@ before_build:
 - dotnet --info
 - dotnet tool restore
 build_script:
-- pwsh: |
+- ps: |
     dotnet build --configuration $env:CONFIGURATION
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
-      Get-ChildItem -File -Filter docopt.net.*.nupkg dist | % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }
+      Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
+        Select-Object -ExpandProperty FullName |
+        % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }
     }
 test_script:
 - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ build_script:
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
+      dotnet sourcelink test (Get-ChildItem -File -Filter docopt.net.*.nupkg dist)
     }
-    dotnet sourcelink test (Get-ChildItem -File -Filter docopt.net.*.nupkg dist)
 test_script:
 - ps: dotnet test
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ init:
 - cmd: git config --global core.autocrlf true
 before_build:
 - dotnet --info
+- dotnet tool restore
 build_script:
 - ps: |
     dotnet build --configuration $env:CONFIGURATION
@@ -19,10 +20,9 @@ build_script:
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
     }
+    dotnet sourcelink test (Get-ChildItem -File -Filter docopt.net.*.nupkg dist)
 test_script:
 - ps: dotnet test
 artifacts:
 - path: 'dist\*.nupkg'
   name: NuGet
-- path: 'dist\*.snupkg'
-  name: NuGet (symbols)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ before_build:
 - dotnet --info
 - dotnet tool restore
 build_script:
-- ps: |
+- pwsh: |
     dotnet build --configuration $env:CONFIGURATION
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -22,8 +22,6 @@
     <PackageProjectUrl>https://github.com/docopt/docopt.net</PackageProjectUrl>
     <PackageIcon>PackageIcon.png</PackageIcon>
     <PackageOutputPath>..\..\dist</PackageOutputPath>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Title>docopt.net, a beautiful command-line parser</Title>
     <Authors>Dinh Doan Van Bien;Vladimir Keleshev</Authors>
     <Description>docopt.net is the .net version of the docopt python beautiful command line parser.  docopt.net helps you define an interface for your command-line app, and automatically generate a parser for it. docopt.net is based on conventions that have been used for decades in help messages and man pages for program interface description.  Interface description in docopt.net is such a help message, but formalized. Check out http://docopt.org for a more detailed explanation.
@@ -56,6 +54,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR enables reproducible builds via [**DotNet.ReproducibleBuilds**](https://www.nuget.org/packages/DotNet.ReproducibleBuilds), which includes [Source Link](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink) support.

**DotNet.ReproducibleBuilds** chooses to [embed symbols by default](https://github.com/dotnet/reproducible-builds/blob/62c8ae6d73783859f12caf27bc3c5e05afd2810b/src/DotNet.ReproducibleBuilds/DotNet.ReproducibleBuilds.props#L5), so for sake of simplicity for now, the publishing of a symbols package is being removed in favour of embedding.

---
PS See also [Improving Debug-time Productivity with Source Link](https://devblogs.microsoft.com/dotnet/improving-debug-time-productivity-with-source-link/).