### PR TITLE
Generate package release notes based on commit & tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,10 @@ init:
 - cmd: git config --global core.autocrlf true
 install:
 - ps: |
-    Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
-    scoop install gh
+    if ($isWindows) {
+      Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
+      scoop install gh
+    }
 before_build:
 - dotnet --info
 - dotnet tool restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ skip_commits:
 configuration: Release
 init:
 - cmd: git config --global core.autocrlf true
+install:
+- ps: |
+    Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
+    scoop install gh
 before_build:
 - dotnet --info
 - dotnet tool restore
@@ -18,7 +22,13 @@ build_script:
     dotnet build --configuration $env:CONFIGURATION
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
-      dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix
+      $nl = "`r`n"
+      if ($env:APPVEYOR_REPO_TAG_NAME -clike 'v*') {
+        $url = gh repo view --json url --jq .url
+        $releaseNotes += "See: ${url}/releases/tag/${env:APPVEYOR_REPO_TAG_NAME}" + $nl + $nl
+      }
+      $releaseNotes += "Commit @ $(git rev-parse HEAD)" + $nl
+      dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix "-p:PackageReleaseNotes=$releaseNotes"
       Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
         Select-Object -ExpandProperty FullName |
         % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -29,10 +29,6 @@
             var arguments = new Docopt().Apply("Usage: prog [-a] [-b] FILE", args);
             if (arguments["-a"].IsTrue) {{ ... }}
     </Description>
-    <PackageReleaseNotes>
-      - T4DocoptNet.tt assembly path fix.
-      - Added support for .net core RC2
-    </PackageReleaseNotes>
     <Copyright>Copyright (c) 2012-2014 Vladimir Keleshev, Dinh Doan Van Bien</Copyright>
     <PackageTags>parser;command line argument;option library;syntax;shell;beautiful;posix;python;console;command-line;docopt</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
This PR removes manual maintenance of package release notes in the project file and instead generates a standard release note based on the hash of the commit during a CI build. If the CI is triggered by a tag using the format `v*` then it adds a URL pointing to the [release on GitHub](https://github.com/docopt/docopt.net/releases) (assuming it's associated with the tag). The notes can then be add to the release on GitHub and easily edited in case of typos or omissions (i.e. not requiring further commits to the repo).
