### PR TITLE
Pack/Test without building (again) during CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,13 +30,13 @@ build_script:
         $releaseNotes += "See: ${url}/releases/tag/${env:APPVEYOR_REPO_TAG_NAME}" + $nl + $nl
       }
       $releaseNotes += "Commit @ $(git rev-parse HEAD)" + $nl
-      dotnet pack --configuration $env:CONFIGURATION --version-suffix $versionSuffix "-p:PackageReleaseNotes=$releaseNotes"
+      dotnet pack --no-build --configuration $env:CONFIGURATION --version-suffix $versionSuffix "-p:PackageReleaseNotes=$releaseNotes"
       Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
         Select-Object -ExpandProperty FullName |
         % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }
     }
 test_script:
-- ps: dotnet test
+- ps: dotnet test --no-build
 artifacts:
 - path: 'dist\*.nupkg'
   name: NuGet


### PR DESCRIPTION
When packing and testing during CI build, the `dotnet pack` and `dotnet test` commands would build the solution again. Since it's an incremental build, it's usually fast but it does produce duplicate output that can be confusing and verbose. This PR adds the `--no-build` option to both commands to simply pack and test.