### PR TITLE
Adjust package version suffix for tagged releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ build_script:
       # if the tag starts with "v", as in "v1.0.0", assume it's a release
       if ($tag -clike 'v*') {
         $url = gh repo view --json url --jq .url
+        if ($LASTEXITCODE) { throw; }
         $releaseNotes += "See: ${url}/releases/tag/$tag" + $nl + $nl
         # if tag ends in "-" followed by dot-separated identifiers...
         if ($tag -match '(?<=-)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$') {
@@ -43,6 +44,7 @@ build_script:
         $packArgs += @('--version-suffix', $versionSuffix)
       }
       dotnet pack --no-build --configuration $env:CONFIGURATION @packArgs "-p:PackageReleaseNotes=$releaseNotes"
+      if ($LASTEXITCODE) { throw; }
       Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
         Select-Object -ExpandProperty FullName |
         % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,24 @@ build_script:
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
       $nl = "`r`n"
-      if ($env:APPVEYOR_REPO_TAG_NAME -clike 'v*') {
+      $tag = $env:APPVEYOR_REPO_TAG_NAME
+      # if the tag starts with "v", as in "v1.0.0", assume it's a release
+      if ($tag -clike 'v*') {
         $url = gh repo view --json url --jq .url
-        $releaseNotes += "See: ${url}/releases/tag/${env:APPVEYOR_REPO_TAG_NAME}" + $nl + $nl
+        $releaseNotes += "See: ${url}/releases/tag/$tag" + $nl + $nl
+        # if tag ends in "-" followed by dot-separated identifiers...
+        if ($tag -match '(?<=-)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$') {
+          $versionSuffix = $matches[0] # ...then use as suffix for pre-release
+        } else {
+          $versionSuffix = $null       # ... else use no suffix for a release
+        }
       }
       $releaseNotes += "Commit @ $(git rev-parse HEAD)" + $nl
-      dotnet pack --no-build --configuration $env:CONFIGURATION --version-suffix $versionSuffix "-p:PackageReleaseNotes=$releaseNotes"
+      $packArgs = @()
+      if ($versionSuffix) {
+        $packArgs += @('--version-suffix', $versionSuffix)
+      }
+      dotnet pack --no-build --configuration $env:CONFIGURATION @packArgs "-p:PackageReleaseNotes=$releaseNotes"
       Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
         Select-Object -ExpandProperty FullName |
         % { dotnet sourcelink test $_; if ($LASTEXITCODE) { throw; } }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,6 @@ skip_commits:
 configuration: Release
 init:
 - cmd: git config --global core.autocrlf true
-install:
-- ps: |
-    if ($isWindows) {
-      Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
-      scoop install gh
-    }
 before_build:
 - dotnet --info
 - dotnet tool restore
@@ -28,7 +22,7 @@ build_script:
       $tag = $env:APPVEYOR_REPO_TAG_NAME
       # if the tag starts with "v", as in "v1.0.0", assume it's a release
       if ($tag -clike 'v*') {
-        $url = gh repo view --json url --jq .url
+        $url = (git remote get-url (git remote)) -replace '\.git$', ''
         if ($LASTEXITCODE) { throw; }
         $releaseNotes += "See: ${url}/releases/tag/$tag" + $nl + $nl
         # if tag ends in "-" followed by dot-separated identifiers...


### PR DESCRIPTION
This PR adjusts the package version suffix for tagged releases. If the CI build is for a tag and that tag starts with a lowercase V (e.g. `v1.2.3`) then the version suffix is nulled and the tag is assumed to represent a release. If the tag has a suffix, dash/hyphen (`-`) followed by dot-separated non-empty identifiers (`[0-9A-Za-z-]`), then the package is assumed to represent a pre-release and the suffix will also be used for the packager version suffix.