### PR TITLE
Add package release notes via file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ packages/
 .vs/
 .paket/Paket.Restore.targets
 dist/
+tmp/
+temp/

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ packages/
 .vs/
 .paket/Paket.Restore.targets
 dist/
-tmp/
-temp/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,14 @@ build_script:
     dotnet build --configuration $env:CONFIGURATION
     if ($isWindows) {
       $versionSuffix = ([datetimeoffset]$env:APPVEYOR_REPO_COMMIT_TIMESTAMP).ToUniversalTime().ToString('yyyyMMdd''t''HHmm')
-      $nl = "`r`n"
+      $releaseNotesFile = [System.IO.Path]::GetTempFileName()
       $tag = $env:APPVEYOR_REPO_TAG_NAME
       # if the tag starts with "v", as in "v1.0.0", assume it's a release
       if ($tag -clike 'v*') {
         $url = (git remote get-url (git remote)) -replace '\.git$', ''
         if ($LASTEXITCODE) { throw; }
-        $releaseNotes += "See: ${url}/releases/tag/$tag" + $nl + $nl
+        Add-Content $releaseNotesFile -Encoding UTF8 "See: ${url}/releases/tag/$tag"
+        Add-Content $releaseNotesFile -Encoding UTF8 ''
         # if tag ends in "-" followed by dot-separated identifiers...
         if ($tag -match '(?<=-)[a-zA-Z0-9-]+(\.[a-zA-Z0-9-]+)*$') {
           $versionSuffix = $matches[0] # ...then use as suffix for pre-release
@@ -32,12 +33,12 @@ build_script:
           $versionSuffix = $null       # ... else use no suffix for a release
         }
       }
-      $releaseNotes += "Commit @ $(git rev-parse HEAD)" + $nl
+      Add-Content $releaseNotesFile -Encoding UTF8 "Commit @ $(git rev-parse HEAD)"
       $packArgs = @()
       if ($versionSuffix) {
         $packArgs += @('--version-suffix', $versionSuffix)
       }
-      dotnet pack --no-build --configuration $env:CONFIGURATION @packArgs "-p:PackageReleaseNotes=$releaseNotes"
+      dotnet pack --no-build --configuration $env:CONFIGURATION @packArgs "-p:PackageReleaseNotesFile=$releaseNotesFile"
       if ($LASTEXITCODE) { throw; }
       Get-ChildItem -File -Filter docopt.net.*.nupkg dist |
         Select-Object -ExpandProperty FullName |

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -22,6 +22,7 @@
     <PackageProjectUrl>https://github.com/docopt/docopt.net</PackageProjectUrl>
     <PackageIcon>PackageIcon.png</PackageIcon>
     <PackageOutputPath>..\..\dist</PackageOutputPath>
+    <PackageReleaseNotes Condition="'$(PackageReleaseNotes)' == '' And '$(PackageReleaseNotesFile)' != ''">$([System.IO.File]::ReadAllText('$(PackageReleaseNotesFile)'))</PackageReleaseNotes>
     <Title>docopt.net, a beautiful command-line parser</Title>
     <Authors>Dinh Doan Van Bien;Vladimir Keleshev</Authors>
     <Description>docopt.net is the .net version of the docopt python beautiful command line parser.  docopt.net helps you define an interface for your command-line app, and automatically generate a parser for it. docopt.net is based on conventions that have been used for decades in help messages and man pages for program interface description.  Interface description in docopt.net is such a help message, but formalized. Check out http://docopt.org for a more detailed explanation.


### PR DESCRIPTION
This PR sets package release notes via a (temporary and generated) file instead of building a string that's passed as an argument, which could be tricky with some shells.