### PR TITLE
Suppress warning RS2002 (possible regression in .NET SDK 6.0.200)

### DIFF
--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -10,6 +10,7 @@
     -->
     <!-- See further below why NU5129 is suppressed. -->
     <NoWarn>$(NoWarn);NU5125;NU5129</NoWarn>
+    <NoWarn Condition="'$(NetCoreSdkVersion)' == '6.0.200'">$(NoWarn);RS2002</NoWarn>
     <AssemblyName>DocoptNet</AssemblyName>
     <VersionPrefix>0.8.0</VersionPrefix>
     <AssemblyOriginatorKeyFile>DocoptNet.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
See dotnet/roslyn-analyzers#5890 for more details.

This PR suppresses RS2002 warnings predicated on the condition that one is building with .NET SDK 6.0.200. This is a stop-gap measure until dotnet/roslyn-analyzers#5890 gets sorted.
