### PR TITLE
Build docs then deploy in separate step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,4 +17,9 @@ jobs:
       - run: |
           pip install mkdocs-material
           pip install mdx_truly_sane_lists
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site


### PR DESCRIPTION
Rather than use [`mkdocs gh-deploy`](https://www.mkdocs.org/user-guide/deploying-your-docs/), this PR separates the documentation build and deployment steps in order to have more control over the two and which could come in hand with multi-versioning the documentation. The deployment step uses [a GitHub action](https://github.com/marketplace/actions/github-pages-action).
