### PR TITLE
Fix source generator to support nested arguments class

### DIFF
--- a/src/DocoptNet/CodeGeneration/CSharpSourceBuilder.cs
+++ b/src/DocoptNet/CodeGeneration/CSharpSourceBuilder.cs
@@ -82,6 +82,16 @@ namespace DocoptNet.CodeGeneration
         public CSharpSourceBuilder this[char code] { get { Append(code); return this; } }
         public CSharpSourceBuilder this[CSharpSourceBuilder code] { get { AssertSame(code); return this; } }
 
+        public CSharpSourceBuilder this[IEnumerable<CSharpSourceBuilder> codes]
+        {
+            get
+            {
+                foreach (var code in codes)
+                    _ = this[code];
+                return this;
+            }
+        }
+
         public CSharpSourceBuilder Blank() => this;
         public CSharpSourceBuilder NewLine { get { AppendLine(); return this; } }
 

--- a/src/DocoptNet/CodeGeneration/Extensions.cs
+++ b/src/DocoptNet/CodeGeneration/Extensions.cs
@@ -18,14 +18,32 @@
 
 namespace DocoptNet.CodeGeneration
 {
+    using System.Collections.Generic;
     using System.Diagnostics;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+
+    static partial class Extensions
+    {
+        /// <remarks>
+        /// Parents are returned in order of nearest to furthest ancestry.
+        /// </remarks>
+        public static IEnumerable<TypeDeclarationSyntax> GetParents(this BaseTypeDeclarationSyntax syntax)
+        {
+            for (var tds = syntax.Parent as TypeDeclarationSyntax;
+                 tds is not null;
+                 tds = tds.Parent as TypeDeclarationSyntax)
+            {
+                yield return tds;
+            }
+        }
+    }
 
     // Inspiration & credit:
     // https://github.com/devlooped/ThisAssembly/blob/43eb32fa24c25ddafda1058a53857ea3e305296a/src/GeneratorExtension.cs
 
-    static partial class Extensions
+    partial class Extensions
     {
         public static void LaunchDebuggerIfFlagged(this GeneratorExecutionContext context,
                                                    string generatorName) =>

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
@@ -187,8 +187,45 @@ Naval Fate.
                         {
                             const string Help = ""Usage: program"";
                         }
+                    }"))
+            });
+        }
+
+        [Test]
+        public void Generate_with_nested_args_class()
+        {
+            AssertMatchesSnapshot(new[]
+            {
+                ("Program.cs", SourceText.From(@"
+                    static partial class Program
+                    {
+                        [DocoptNet.DocoptArguments]
+                        sealed partial class Arguments
+                        {
+                            const string Help = ""Usage: program"";
+                        }
+
+                        partial class Nested
+                        {
+                            [DocoptNet.DocoptArguments]
+                            sealed partial class Arguments
+                            {
+                                const string Help = ""Usage: program"";
+                            }
+                        }
                     }
-                    "))
+
+                    namespace MyConsoleApp
+                    {
+                        static partial class Program
+                        {
+                            [DocoptNet.DocoptArguments]
+                            sealed partial class Arguments
+                            {
+                                const string Help = ""Usage: program"";
+                            }
+                        }
+                    }"))
             });
         }
 

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/MyConsoleApp.Program-Arguments.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/MyConsoleApp.Program-Arguments.cs
@@ -1,0 +1,77 @@
+#nullable enable annotations
+
+using System.Collections;
+using System.Collections.Generic;
+using DocoptNet;
+using DocoptNet.Internals;
+using Leaves = DocoptNet.Internals.ReadOnlyList<DocoptNet.Internals.LeafPattern>;
+
+namespace MyConsoleApp
+{
+    partial class Program
+    {
+        partial class Arguments : IEnumerable<KeyValuePair<string, object?>>
+        {
+            public const string Usage = "Usage: program";
+
+            static readonly IBaselineParser<Arguments> Parser = GeneratedSourceModule.CreateParser(Help, Parse);
+
+            public static IBaselineParser<Arguments> CreateParser() => Parser;
+
+            static IParser<Arguments>.IResult Parse(IEnumerable<string> args, ParseFlags flags, string? version)
+            {
+                var options = new List<Option>
+                {
+                };
+
+                return GeneratedSourceModule.Parse(Help, Usage, args, options, flags, version, Parse);
+
+                static IParser<Arguments>.IResult Parse(Leaves left)
+                {
+                    var required = new RequiredMatcher(1, left, new Leaves());
+                    Match(ref required);
+                    if (!required.Result || required.Left.Count > 0)
+                    {
+                        return GeneratedSourceModule.CreateInputErrorResult<Arguments>(string.Empty, Usage);
+                    }
+                    var collected = required.Collected;
+                    var result = new Arguments();
+
+                    return GeneratedSourceModule.CreateArgumentsResult(result);
+                }
+
+                static void Match(ref RequiredMatcher required)
+                {
+                    // Required(Required())
+                    var a = new RequiredMatcher(1, required.Left, required.Collected);
+                    while (a.Next())
+                    {
+                        // Required()
+                        var b = new RequiredMatcher(0, a.Left, a.Collected);
+                        while (b.Next())
+                        {
+                            if (!b.LastMatched)
+                            {
+                                break;
+                            }
+                        }
+                        a.Fold(b.Result);
+                        if (!a.LastMatched)
+                        {
+                            break;
+                        }
+                    }
+                    required.Fold(a.Result);
+                }
+            }
+
+            IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                yield break;
+            }
+
+            IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/Program-Arguments.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/Program-Arguments.cs
@@ -1,0 +1,74 @@
+#nullable enable annotations
+
+using System.Collections;
+using System.Collections.Generic;
+using DocoptNet;
+using DocoptNet.Internals;
+using Leaves = DocoptNet.Internals.ReadOnlyList<DocoptNet.Internals.LeafPattern>;
+
+partial class Program
+{
+    partial class Arguments : IEnumerable<KeyValuePair<string, object?>>
+    {
+        public const string Usage = "Usage: program";
+
+        static readonly IBaselineParser<Arguments> Parser = GeneratedSourceModule.CreateParser(Help, Parse);
+
+        public static IBaselineParser<Arguments> CreateParser() => Parser;
+
+        static IParser<Arguments>.IResult Parse(IEnumerable<string> args, ParseFlags flags, string? version)
+        {
+            var options = new List<Option>
+            {
+            };
+
+            return GeneratedSourceModule.Parse(Help, Usage, args, options, flags, version, Parse);
+
+            static IParser<Arguments>.IResult Parse(Leaves left)
+            {
+                var required = new RequiredMatcher(1, left, new Leaves());
+                Match(ref required);
+                if (!required.Result || required.Left.Count > 0)
+                {
+                    return GeneratedSourceModule.CreateInputErrorResult<Arguments>(string.Empty, Usage);
+                }
+                var collected = required.Collected;
+                var result = new Arguments();
+
+                return GeneratedSourceModule.CreateArgumentsResult(result);
+            }
+
+            static void Match(ref RequiredMatcher required)
+            {
+                // Required(Required())
+                var a = new RequiredMatcher(1, required.Left, required.Collected);
+                while (a.Next())
+                {
+                    // Required()
+                    var b = new RequiredMatcher(0, a.Left, a.Collected);
+                    while (b.Next())
+                    {
+                        if (!b.LastMatched)
+                        {
+                            break;
+                        }
+                    }
+                    a.Fold(b.Result);
+                    if (!a.LastMatched)
+                    {
+                        break;
+                    }
+                }
+                required.Fold(a.Result);
+            }
+        }
+
+        IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            yield break;
+        }
+
+        IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/Program-Nested-Arguments.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests/Generate_with_nested_args_class/Program-Nested-Arguments.cs
@@ -1,0 +1,77 @@
+#nullable enable annotations
+
+using System.Collections;
+using System.Collections.Generic;
+using DocoptNet;
+using DocoptNet.Internals;
+using Leaves = DocoptNet.Internals.ReadOnlyList<DocoptNet.Internals.LeafPattern>;
+
+partial class Program
+{
+    partial class Nested
+    {
+        partial class Arguments : IEnumerable<KeyValuePair<string, object?>>
+        {
+            public const string Usage = "Usage: program";
+
+            static readonly IBaselineParser<Arguments> Parser = GeneratedSourceModule.CreateParser(Help, Parse);
+
+            public static IBaselineParser<Arguments> CreateParser() => Parser;
+
+            static IParser<Arguments>.IResult Parse(IEnumerable<string> args, ParseFlags flags, string? version)
+            {
+                var options = new List<Option>
+                {
+                };
+
+                return GeneratedSourceModule.Parse(Help, Usage, args, options, flags, version, Parse);
+
+                static IParser<Arguments>.IResult Parse(Leaves left)
+                {
+                    var required = new RequiredMatcher(1, left, new Leaves());
+                    Match(ref required);
+                    if (!required.Result || required.Left.Count > 0)
+                    {
+                        return GeneratedSourceModule.CreateInputErrorResult<Arguments>(string.Empty, Usage);
+                    }
+                    var collected = required.Collected;
+                    var result = new Arguments();
+
+                    return GeneratedSourceModule.CreateArgumentsResult(result);
+                }
+
+                static void Match(ref RequiredMatcher required)
+                {
+                    // Required(Required())
+                    var a = new RequiredMatcher(1, required.Left, required.Collected);
+                    while (a.Next())
+                    {
+                        // Required()
+                        var b = new RequiredMatcher(0, a.Left, a.Collected);
+                        while (b.Next())
+                        {
+                            if (!b.LastMatched)
+                            {
+                                break;
+                            }
+                        }
+                        a.Fold(b.Result);
+                        if (!a.LastMatched)
+                        {
+                            break;
+                        }
+                    }
+                    required.Fold(a.Result);
+                }
+            }
+
+            IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+            {
+                yield break;
+            }
+
+            IEnumerator<KeyValuePair<string, object?>> IEnumerable<KeyValuePair<string, object?>>.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+    }
+}

--- a/tests/Integration/NavalFateTests.cs
+++ b/tests/Integration/NavalFateTests.cs
@@ -165,4 +165,19 @@ namespace DocoptNet.Tests.Integration
                 base(Integration.InlineNavalFateArguments.CreateParser()) { }
         }
     }
+
+    public static partial class NavalFateProgram
+    {
+        [DocoptArguments]
+        public sealed partial class Arguments : INavalFateArguments
+        {
+            const string Help = InlineNavalFateArguments.Help;
+        }
+    }
+
+    public class NestedNavalFateTests : NavalFateTestsBase<NavalFateProgram.Arguments>
+    {
+        public NestedNavalFateTests() :
+            base(NavalFateProgram.Arguments.CreateParser()) { }
+    }
 }


### PR DESCRIPTION
This PR fixes issue #173.

It only supports classes as parents. Records and structures are not being addressed because those would be extremely rare cases.
