### PR TITLE
Remove .NET 5 target that's reached end-of-life

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,14 +15,12 @@ install:
 - ps: |
     if ($isWindows) {
       ./dotnet-install.ps1 -JsonFile global.json
-      ./dotnet-install.ps1 -Runtime dotnet -Version 5.0.13 -SkipNonVersionedFiles
       ./dotnet-install.ps1 -Runtime dotnet -Version 3.1.22 -SkipNonVersionedFiles
     }
 - sh: |
     curl -OsSL https://dot.net/v1/dotnet-install.sh
     chmod +x dotnet-install.sh
     ./dotnet-install.sh --jsonfile global.json
-    ./dotnet-install.sh --runtime dotnet --version 5.0.13 --skip-non-versioned-files
     ./dotnet-install.sh --runtime dotnet --version 3.1.22 --skip-non-versioned-files
     export PATH="$HOME/.dotnet:$PATH"
 before_build:

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
@@ -572,7 +572,7 @@ public partial class " + ProgramArgumentsClassName + @" { }
                                          trees, references: null,
                                          new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
                                                                       generalDiagnosticOption: ReportDiagnostic.Error))
-                                 .WithReferenceAssemblies(ReferenceAssemblyKind.Net50)
+                                 .WithReferenceAssemblies(ReferenceAssemblyKind.Net60)
                                  .AddReferences(MetadataReference.CreateFromFile(Path.Combine(TestContext.CurrentContext.TestDirectory, "Newtonsoft.Json.dll")))
                                  .AddReferences(MetadataReference.CreateFromFile(typeof(Docopt).Assembly.Location));
 

--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net47</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\src\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/tests/Integration/DocoptNet.Tests.Integration.csproj
+++ b/tests/Integration/DocoptNet.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RestoreAdditionalProjectSources>$(MSBuildThisFileDirectory)..\..\dist</RestoreAdditionalProjectSources>
     <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>


### PR DESCRIPTION
This PR removes .NET 5 as target since it reached [end-of-life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) on May 10, 2022.