### PR TITLE
Remove testing on .NET Core 3.1 that's no longer supported

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,12 @@ install:
     if ($isWindows) {
       ./dotnet-install.ps1 -JsonFile global.json
       ./dotnet-install.ps1 -Runtime dotnet -Version 6.0.12 -SkipNonVersionedFiles
-      ./dotnet-install.ps1 -Runtime dotnet -Version 3.1.22 -SkipNonVersionedFiles
     }
 - sh: |
     curl -OsSL https://dot.net/v1/dotnet-install.sh
     chmod +x dotnet-install.sh
     ./dotnet-install.sh --jsonfile global.json
     ./dotnet-install.sh --runtime dotnet --version 6.0.12 --skip-non-versioned-files
-    ./dotnet-install.sh --runtime dotnet --version 3.1.22 --skip-non-versioned-files
     export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net47</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\src\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net47'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net47'">
     <Compile Remove="CodeGeneration\*.cs" />
     <None Remove="CodeGeneration\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
This PR removes testing on .NET Core 3.1 that's no longer supported. It [reached end of support on December 13, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core).