### PR TITLE
Update .NET SDK, target runtime & packages

### DIFF
--- a/eg/SourceGenerator/Directory.Build.props
+++ b/eg/SourceGenerator/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..'))" />
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <DebugDocoptNet>false</DebugDocoptNet>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestFeature"
+    "version": "8.0.300",
+    "rollForward": "latestPatch"
   }
 }

--- a/src/DocoptNet.Playground/DocoptNet.Playground.csproj
+++ b/src/DocoptNet.Playground/DocoptNet.Playground.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.1" PrivateAssets="all" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.6" PrivateAssets="all" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 
   <!--

--- a/src/DocoptNet/DocoptNet.csproj
+++ b/src/DocoptNet/DocoptNet.csproj
@@ -11,7 +11,7 @@
     <!-- See further below why NU5129 is suppressed. -->
     <NoWarn>$(NoWarn);NU5125;NU5129</NoWarn>
     <AssemblyName>DocoptNet</AssemblyName>
-    <VersionPrefix>0.8.2</VersionPrefix>
+    <VersionPrefix>0.8.3</VersionPrefix>
     <AssemblyOriginatorKeyFile>DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -76,11 +76,11 @@ Portions Copyright (C) West Wind Technologies, 2008.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="PolySharp" Version="1.8.1">
+    <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net47</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net47</TargetFrameworks>
     <AssemblyOriginatorKeyFile>..\..\src\DocoptNet\DocoptNet.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -27,12 +27,12 @@
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies" Version="1.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="morelinq" Version="4.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/tests/Integration/DocoptNet.Tests.Integration.csproj
+++ b/tests/Integration/DocoptNet.Tests.Integration.csproj
@@ -1,17 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RestoreAdditionalProjectSources>$(MSBuildThisFileDirectory)..\..\dist</RestoreAdditionalProjectSources>
     <RestorePackagesPath>$(MSBuildThisFileDirectory).nuget</RestorePackagesPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="docopt.net" Version="0.8.1-*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="docopt.net" Version="0.8.3-*" />
   </ItemGroup>
 
   <Target Name="Inspect">

--- a/tests/LanguageAgnosticTests/Dockerfile
+++ b/tests/LanguageAgnosticTests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0.101-alpine3.16-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0.300-alpine3.19-amd64 AS build
 
 WORKDIR /project
 
@@ -8,11 +8,11 @@ COPY tests/LanguageAgnosticTests tests/LanguageAgnosticTests
 
 RUN dotnet build tests/LanguageAgnosticTests
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0.1-alpine3.16-amd64
+FROM mcr.microsoft.com/dotnet/runtime:8.0.6-alpine3.19-amd64
 
 WORKDIR /tests
 
-COPY --from=build /project/tests/LanguageAgnosticTests/bin/Debug/net7.0/ bin
+COPY --from=build /project/tests/LanguageAgnosticTests/bin/Debug/net8.0/ bin
 COPY --from=build /project/tests/LanguageAgnosticTests/*.py .
 COPY --from=build /project/tests/LanguageAgnosticTests/*.docopt .
 

--- a/tests/LanguageAgnosticTests/README.md
+++ b/tests/LanguageAgnosticTests/README.md
@@ -5,13 +5,13 @@ Compile the **Testee** project then run the following commands:
 
     cd tests/LanguageAgnosticTests
     dotnet build
-    python language_agnostic_tester.py bin/Debug/net7.0/Testee
+    python language_agnostic_tester.py bin/Debug/net8.0/Testee
 
 On Windows, use the following commands:
 
     dotnet build tests\LanguageAgnosticTests
     cd tests\LanguageAgnosticTests
-    python language_agnostic_tester.py bin\Debug\net7.0\Testee.exe
+    python language_agnostic_tester.py bin\Debug\net8.0\Testee.exe
 
 Alternatively, build and run the following Docker image (assuming the current
 working directory is the same as the directory containing this file):

--- a/tests/LanguageAgnosticTests/Testee.csproj
+++ b/tests/LanguageAgnosticTests/Testee.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Summary of changes in this PR:

- The .NET SDK is updated to version 8.
- The .NET 7 runtime is removed ([support ended in May 2024](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)) from list of targets and replaced with version 8.
- All packages, except Roslyn and NUnit, are updated to their latest versions.
- NUnit is not updated to version 4.x due to [breaking changes](https://docs.nunit.org/articles/nunit/release-notes/breaking-changes.html#nunit-40).
