### PR TITLE
Update to NUnit 4

### DIFF
--- a/tests/DocoptNet.Tests/ArgumentMatchTests.cs
+++ b/tests/DocoptNet.Tests/ArgumentMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ArgumentMatchTests

--- a/tests/DocoptNet.Tests/ArgumentTests.cs
+++ b/tests/DocoptNet.Tests/ArgumentTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ArgumentTests

--- a/tests/DocoptNet.Tests/Assumptions.cs
+++ b/tests/DocoptNet.Tests/Assumptions.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     /// <summary>
     ///     Set of tests to validate assumptions about the BCL or other APIs.

--- a/tests/DocoptNet.Tests/BasicPatternMatchingTests.cs
+++ b/tests/DocoptNet.Tests/BasicPatternMatchingTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class BasicPatternMatchingTests

--- a/tests/DocoptNet.Tests/CodeGeneration/LanguageAgnosticTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/LanguageAgnosticTests.cs
@@ -4,6 +4,7 @@ namespace DocoptNet.Tests.CodeGeneration
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Globalization;
     using System.Reflection;
     using System.Text.RegularExpressions;
@@ -100,6 +101,7 @@ public partial class Program
             if (expected.StartsWith("{"))
             {
                 var expectedDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(expected);
+                Debug.Assert(expectedDict is not null);
                 var actualDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(actual);
                 Assert.That(actualDict, Is.EquivalentTo(expectedDict));
             }
@@ -107,7 +109,7 @@ public partial class Program
             {
                 var expected1 = JsonConvert.DeserializeObject(expected)!.ToString();
                 var actual1 = JsonConvert.DeserializeObject(actual)!.ToString();
-                Assert.AreEqual(expected1, actual1);
+                Assert.That(actual1, Is.EqualTo(expected1));
             }
         }
     }

--- a/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
+++ b/tests/DocoptNet.Tests/CodeGeneration/SourceGeneratorTests.cs
@@ -267,8 +267,9 @@ Naval Fate.
 
             var diagnostics = outputCompilation.GetDiagnostics();
 
-            Assert.False(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
-                         "Failed: " + diagnostics.FirstOrDefault()?.GetMessage());
+            Assert.That(diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
+                        Is.False,
+                        "Failed: " + diagnostics.FirstOrDefault()?.GetMessage());
 
             var testPath = Path.Combine(nameof(SourceGeneratorTests), callerName!);
             var actualSourcesPath = Path.Combine(TestContext.CurrentContext.WorkDirectory, testPath);
@@ -601,14 +602,16 @@ public partial class " + ProgramArgumentsClassName + @" { }
                                                      out var outputCompilation,
                                                      out var generateDiagnostics);
 
-            Assert.False(generateDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
-                         "Failed: " + generateDiagnostics.FirstOrDefault()?.GetMessage());
+            Assert.That(generateDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
+                        Is.False,
+                        "Failed: " + generateDiagnostics.FirstOrDefault()?.GetMessage());
 
             using var ms = new MemoryStream();
             var emitResult = outputCompilation.Emit(ms);
 
-            Assert.False(emitResult.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
-                         "Failed: " + emitResult.Diagnostics.FirstOrDefault());
+            Assert.That(emitResult.Diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error),
+                        Is.False,
+                        "Failed: " + emitResult.Diagnostics.FirstOrDefault());
 
             ms.Position = 0;
 

--- a/tests/DocoptNet.Tests/CommandMatchTests.cs
+++ b/tests/DocoptNet.Tests/CommandMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class CommandMatchTests

--- a/tests/DocoptNet.Tests/CommandsTests.cs
+++ b/tests/DocoptNet.Tests/CommandsTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class CommandsTests

--- a/tests/DocoptNet.Tests/CountMultipleFlagsTests.cs
+++ b/tests/DocoptNet.Tests/CountMultipleFlagsTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class CountMultipleFlagsTests

--- a/tests/DocoptNet.Tests/DefaultValueForPositionalArgumentsTests.cs
+++ b/tests/DocoptNet.Tests/DefaultValueForPositionalArgumentsTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class DefaultValueForPositionalArgumentsTests

--- a/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
+++ b/tests/DocoptNet.Tests/DocoptNet.Tests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="morelinq" Version="4.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/tests/DocoptNet.Tests/DocoptTests.cs
+++ b/tests/DocoptNet.Tests/DocoptTests.cs
@@ -4,6 +4,8 @@ namespace DocoptNet.Tests
     using System.Linq;
     using NUnit.Framework;
     using Shouldly;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
+    using StringAssert = NUnit.Framework.Legacy.StringAssert;
 
     [TestFixture]
     public class DocoptTests

--- a/tests/DocoptNet.Tests/EitherMatchTests.cs
+++ b/tests/DocoptNet.Tests/EitherMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class EitherMatchTests

--- a/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
+++ b/tests/DocoptNet.Tests/GenerateCodeHelperTest.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class GenerateCodeHelperTest

--- a/tests/DocoptNet.Tests/LanguageAgnosticTests.cs
+++ b/tests/DocoptNet.Tests/LanguageAgnosticTests.cs
@@ -9,6 +9,7 @@ namespace DocoptNet.Tests
     using Newtonsoft.Json;
     using NUnit.Framework;
     using Shouldly;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class LanguageAgnosticTests

--- a/tests/DocoptNet.Tests/ListArgumentMatchTests.cs
+++ b/tests/DocoptNet.Tests/ListArgumentMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ListArgumentMatchTests

--- a/tests/DocoptNet.Tests/OneOrMoreMatchTests.cs
+++ b/tests/DocoptNet.Tests/OneOrMoreMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OneOrMoreMatchTests

--- a/tests/DocoptNet.Tests/OptionMatchTests.cs
+++ b/tests/DocoptNet.Tests/OptionMatchTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using NUnit.Framework;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OptionMatchTests

--- a/tests/DocoptNet.Tests/OptionNameTests.cs
+++ b/tests/DocoptNet.Tests/OptionNameTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OptionNameTests

--- a/tests/DocoptNet.Tests/OptionParseTests.cs
+++ b/tests/DocoptNet.Tests/OptionParseTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OptionParseTests

--- a/tests/DocoptNet.Tests/OptionalMatchTests.cs
+++ b/tests/DocoptNet.Tests/OptionalMatchTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OptionalMatchTests

--- a/tests/DocoptNet.Tests/OptionsFirstTests.cs
+++ b/tests/DocoptNet.Tests/OptionsFirstTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class OptionsFirstTests

--- a/tests/DocoptNet.Tests/ParseArgvTests.cs
+++ b/tests/DocoptNet.Tests/ParseArgvTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using System;
     using static DocoptNet.Tests.ArgumentFactory;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ParseArgvTests

--- a/tests/DocoptNet.Tests/ParseDefaultsTests.cs
+++ b/tests/DocoptNet.Tests/ParseDefaultsTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ParseDefaultsTests

--- a/tests/DocoptNet.Tests/ParsePatternTests.cs
+++ b/tests/DocoptNet.Tests/ParsePatternTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class ParsePatternTests

--- a/tests/DocoptNet.Tests/ParserApiTests.cs
+++ b/tests/DocoptNet.Tests/ParserApiTests.cs
@@ -38,12 +38,12 @@ public class ParserApiTests
         switch (Parse("ship new foo bar"))
         {
             case IArgumentsResult<IDictionary<string, ArgValue>> { Arguments: var args }:
-                Assert.True(args["ship"].IsTrue);
-                Assert.True(args["new"].IsTrue);
+                Assert.That(args["ship"].IsTrue, Is.True);
+                Assert.That(args["new"].IsTrue, Is.True);
                 Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
                 break;
             case var result:
-                Assert.Fail("Unexpected result: {0}", result);
+                Assert.Fail($"Unexpected result: {result}");
                 break;
         }
     }
@@ -57,7 +57,7 @@ public class ParserApiTests
                 Assert.That(result.Help, Is.EqualTo(Help));
                 break;
             case var result:
-                Assert.Fail("Unexpected result: {0}", result);
+                Assert.Fail($"Unexpected result: {result}");
                 break;
         }
     }
@@ -71,7 +71,7 @@ public class ParserApiTests
                 Assert.That(result.Version, Is.EqualTo(Version));
                 break;
             case var result:
-                Assert.Fail("Unexpected result: {0}", result);
+                Assert.Fail($"Unexpected result: {result}");
                 break;
         }
     }
@@ -87,7 +87,7 @@ public class ParserApiTests
                 Assert.That(result.Usage, Is.EqualTo(Usage));
                 break;
             case var result:
-                Assert.Fail("Unexpected result: {0}", result);
+                Assert.Fail($"Unexpected result: {result}");
                 break;
         }
     }
@@ -101,8 +101,8 @@ public class ParserApiTests
                          _ => throw new NUnitException(),
                          _ => throw new NUnitException(),
                          _ => throw new NUnitException());
-        Assert.True(args["ship"].IsTrue);
-        Assert.True(args["new"].IsTrue);
+        Assert.That(args["ship"].IsTrue, Is.True);
+        Assert.That(args["new"].IsTrue, Is.True);
         Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
     }
 
@@ -157,8 +157,8 @@ public class ParserApiTests
                                     _ => throw new NUnitException(),
                                     _ => throw new NUnitException(),
                                     _ => throw new NUnitException());
-            Assert.True(args["ship"].IsTrue);
-            Assert.True(args["new"].IsTrue);
+            Assert.That(args["ship"].IsTrue, Is.True);
+            Assert.That(args["new"].IsTrue, Is.True);
             Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
         }
 
@@ -212,8 +212,8 @@ public class ParserApiTests
                              .Match(args => args,
                                     _ => throw new NUnitException(),
                                     _ => throw new NUnitException());
-            Assert.True(args["ship"].IsTrue);
-            Assert.True(args["new"].IsTrue);
+            Assert.That(args["ship"].IsTrue, Is.True);
+            Assert.That(args["new"].IsTrue, Is.True);
             Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
         }
 
@@ -254,8 +254,8 @@ public class ParserApiTests
                              .Match(args => args,
                                     _ => throw new NUnitException(),
                                     _ => throw new NUnitException());
-            Assert.True(args["ship"].IsTrue);
-            Assert.True(args["new"].IsTrue);
+            Assert.That(args["ship"].IsTrue, Is.True);
+            Assert.That(args["new"].IsTrue, Is.True);
             Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
         }
 
@@ -295,8 +295,8 @@ public class ParserApiTests
             var args = Parser.Parse(Args.Parse("ship new foo bar").List)
                              .Match(args => args,
                                     _ => throw new NUnitException());
-            Assert.True(args["ship"].IsTrue);
-            Assert.True(args["new"].IsTrue);
+            Assert.That(args["ship"].IsTrue, Is.True);
+            Assert.That(args["new"].IsTrue, Is.True);
             Assert.That((StringList)args["<name>"], Is.EqualTo(new[] { "foo", "bar" }));
         }
 

--- a/tests/DocoptNet.Tests/PatterEitherTests.cs
+++ b/tests/DocoptNet.Tests/PatterEitherTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class PatterEitherTests

--- a/tests/DocoptNet.Tests/PatternFixIdentitiesTests.cs
+++ b/tests/DocoptNet.Tests/PatternFixIdentitiesTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class PatternFixIdentitiesTests

--- a/tests/DocoptNet.Tests/PatternFixRepeatingArgumentsTests.cs
+++ b/tests/DocoptNet.Tests/PatternFixRepeatingArgumentsTests.cs
@@ -3,6 +3,7 @@ namespace DocoptNet.Tests
     using System;
     using NUnit.Framework;
     using static DocoptNet.Tests.ArgumentFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class PatternFixRepeatingArgumentsTests

--- a/tests/DocoptNet.Tests/PatternFlatTests.cs
+++ b/tests/DocoptNet.Tests/PatternFlatTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class PatternFlatTests

--- a/tests/DocoptNet.Tests/RequiredMatchTests.cs
+++ b/tests/DocoptNet.Tests/RequiredMatchTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using NUnit.Framework;
     using static DocoptNet.Tests.PatternFactory;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class RequiredMatchTests

--- a/tests/DocoptNet.Tests/StringPartitionTests.cs
+++ b/tests/DocoptNet.Tests/StringPartitionTests.cs
@@ -1,6 +1,7 @@
 namespace DocoptNet.Tests
 {
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class StringPartitionTests

--- a/tests/DocoptNet.Tests/SyntaxTests.cs
+++ b/tests/DocoptNet.Tests/SyntaxTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class SyntaxTests

--- a/tests/DocoptNet.Tests/UsageTests.cs
+++ b/tests/DocoptNet.Tests/UsageTests.cs
@@ -2,6 +2,7 @@ namespace DocoptNet.Tests
 {
     using System.Linq;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
 
     [TestFixture]
     public class UsageTests

--- a/tests/DocoptNet.Tests/ValueObjectTests.cs
+++ b/tests/DocoptNet.Tests/ValueObjectTests.cs
@@ -3,6 +3,8 @@ namespace DocoptNet.Tests
     using System.Collections;
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Assert = NUnit.Framework.Legacy.ClassicAssert;
+    using CollectionAssert = NUnit.Framework.Legacy.CollectionAssert;
 
     [TestFixture]
     public class ValueObjectTests


### PR DESCRIPTION
This PR updates to use NUnit 4, but still uses some legacy assertion methods to keep the migration effort minimal for now.
