### PR TITLE
Adding names of arguments/options that have not been matched

### DIFF
--- a/src/DocoptNet/CodeGeneration/SourceGenerator.cs
+++ b/src/DocoptNet/CodeGeneration/SourceGenerator.cs
@@ -299,7 +299,7 @@ namespace DocoptNet.CodeGeneration
                             .Var("required")[code.New["RequiredMatcher(1, left, "].New["Leaves()"][')']]
                             ["Match(ref required)"].EndStatement
                             .If["!required.Result || required.Left.Count > 0"][code
-                                .Return[code["GeneratedSourceModule.CreateInputErrorResult<"][name][">(string.Empty, "][usageConstName][")"]]]
+                                .Return[code["GeneratedSourceModule.CreateInputErrorResult<"][name][">(required.Left.Count > 0 ? required.LeftNames() : string.Empty, "][usageConstName][")"]]]
                             .Var("collected")["required.Collected"]
                             .Var("result")[code.New[name]["()"]]
                             [leaves.Any()

--- a/src/DocoptNet/Internals/PatternMatcher.cs
+++ b/src/DocoptNet/Internals/PatternMatcher.cs
@@ -69,6 +69,9 @@ namespace DocoptNet.Internals
         public bool Next() => BranchPatternMatcher.Next(ref _i, _count);
 
         public Leaves Left { get; private set; }
+
+        public string LeftNames() => string.Join(", ", Left.Select(x => x.Name));
+
         public Leaves Collected { get; private set; }
 
         public bool Match(LeafPatternMatcher matcher, string name, ArgValueKind kind) =>


### PR DESCRIPTION
While developing a product using docopt, it became obvious that the error message parameter of the InputErrorResult was unpopulated, with only the usage being populated.

It became frustrating trying to figure out why the parse was failing.

This change adds the name of the unmatched fields as a CSV string to the error parameter.